### PR TITLE
VER: Release 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.15.0 - 2023-01-13
+## 0.15.0 - 2023-01-16
 
 ### Breaking changes
 - Increased size of `SystemMsg` and `ErrorMsg` to provide better messages from Live

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.15.0 - TBD
+
+### Breaking changes
+- Increased size of `SystemMsg` and `ErrorMsg` to provide better messages from Live
+  gateway
+  - Increased length of `err` and `msg` fields for more detailed messages
+  - Added `is_last` field to `ErrorMsg` to indicate the last error in a chain
+  - Added `code` field to `SystemMsg` and `ErrorMsg`, although currently unused
+  - Added new `is_last` parameter to `ErrorMsg::new`
+  - Decoding these is backwards-compatible and records with longer messages won't be
+    sent during the DBN version 2 migration period
+  - Renamed previous records to `ErrorMsgV1` and `SystemMsgV1`
+
 ## 0.14.1 - 2023-12-18
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.15.0 - TBD
+## 0.15.0 - 2023-01-13
 
 ### Breaking changes
 - Increased size of `SystemMsg` and `ErrorMsg` to provide better messages from Live

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.14)
 # Project details
 #
 
-project("databento" VERSION 0.14.1 LANGUAGES CXX)
+project("databento" VERSION 0.15.0 LANGUAGES CXX)
 string(TOUPPER ${PROJECT_NAME} PROJECT_NAME_UPPERCASE)
 
 #

--- a/example/live/simple.cpp
+++ b/example/live/simple.cpp
@@ -29,7 +29,7 @@ int main() {
   // Set up signal handler for Ctrl+C
   std::signal(SIGINT, [](int signal) { gSignal = signal; });
 
-  std::vector<std::string> symbols{"ESM3", "ESM3 C4200", "ESM3 P4100"};
+  std::vector<std::string> symbols{"ESZ4", "ESZ4 C4200", "ESZ4 P4100"};
   client.Subscribe(symbols, databento::Schema::Definition,
                    databento::SType::RawSymbol);
   client.Subscribe(symbols, databento::Schema::Mbo,

--- a/include/databento/record.hpp
+++ b/include/databento/record.hpp
@@ -337,9 +337,11 @@ struct ErrorMsg {
   const char* Err() const { return err.data(); }
 
   RecordHeader hd;
-  std::array<char, 64> err;
+  std::array<char, 302> err;
+  std::uint8_t code;
+  std::uint8_t is_last;
 };
-static_assert(sizeof(ErrorMsg) == 80, "ErrorMsg size must match Rust");
+static_assert(sizeof(ErrorMsg) == 320, "ErrorMsg size must match Rust");
 static_assert(alignof(ErrorMsg) == 8, "Must have 8-byte alignment");
 
 /// A symbol mapping message.
@@ -372,9 +374,10 @@ struct SystemMsg {
   }
 
   RecordHeader hd;
-  std::array<char, 64> msg;
+  std::array<char, 303> msg;
+  std::uint8_t code;
 };
-static_assert(sizeof(SystemMsg) == 80, "SystemMsg size must match Rust");
+static_assert(sizeof(SystemMsg) == 320, "SystemMsg size must match Rust");
 static_assert(alignof(SystemMsg) == 8, "Must have 8-byte alignment");
 
 inline bool operator==(const RecordHeader& lhs, const RecordHeader& rhs) {
@@ -480,14 +483,15 @@ inline bool operator!=(const StatMsg& lhs, const StatMsg& rhs) {
 }
 
 inline bool operator==(const ErrorMsg& lhs, const ErrorMsg& rhs) {
-  return lhs.hd == rhs.hd && lhs.err == rhs.err;
+  return lhs.hd == rhs.hd && lhs.err == rhs.err && lhs.code == rhs.code &&
+         lhs.is_last == rhs.is_last;
 }
 inline bool operator!=(const ErrorMsg& lhs, const ErrorMsg& rhs) {
   return !(lhs == rhs);
 }
 
 inline bool operator==(const SystemMsg& lhs, const SystemMsg& rhs) {
-  return lhs.hd == rhs.hd && lhs.msg == rhs.msg;
+  return lhs.hd == rhs.hd && lhs.msg == rhs.msg && lhs.code == rhs.code;
 }
 inline bool operator!=(const SystemMsg& lhs, const SystemMsg& rhs) {
   return !(lhs == rhs);

--- a/pkg/PKGBUILD
+++ b/pkg/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Databento <support@databento.com>
 _pkgname=databento-cpp
 pkgname=databento-cpp-git
-pkgver=0.14.1
+pkgver=0.15.0
 pkgrel=1
 pkgdesc="Official C++ client for Databento"
 arch=('any')

--- a/src/compat.cpp
+++ b/src/compat.cpp
@@ -92,6 +92,17 @@ InstrumentDefMsgV2 InstrumentDefMsgV1::ToV2() const {
   return ret;
 }
 
+ErrorMsgV2 ErrorMsgV1::ToV2() const {
+  ErrorMsgV2 ret{
+      RecordHeader{sizeof(ErrorMsgV2) / RecordHeader::kLengthMultiplier,
+                   RType::Error, hd.publisher_id, hd.instrument_id},
+      {},
+      std::numeric_limits<std::uint8_t>::max(),
+      std::numeric_limits<std::uint8_t>::max()};
+  std::copy(err.begin(), err.end(), ret.err.begin());
+  return ret;
+}
+
 SymbolMappingMsgV2 SymbolMappingMsgV1::ToV2() const {
   SymbolMappingMsgV2 ret{
       RecordHeader{sizeof(SymbolMappingMsgV2) / RecordHeader::kLengthMultiplier,
@@ -108,6 +119,16 @@ SymbolMappingMsgV2 SymbolMappingMsgV1::ToV2() const {
             ret.stype_in_symbol.begin());
   std::copy(stype_out_symbol.begin(), stype_out_symbol.end(),
             ret.stype_out_symbol.begin());
+  return ret;
+}
+
+SystemMsgV2 SystemMsgV1::ToV2() const {
+  SystemMsgV2 ret{
+      RecordHeader{sizeof(SystemMsgV2) / RecordHeader::kLengthMultiplier,
+                   RType::System, hd.publisher_id, hd.instrument_id},
+      {},
+      std::numeric_limits<std::uint8_t>::max()};
+  std::copy(msg.begin(), msg.end(), ret.msg.begin());
   return ret;
 }
 
@@ -245,6 +266,16 @@ std::ostream& operator<<(std::ostream& stream,
       .AddField("tick_rule", instr_def_msg.tick_rule)
       .Finish();
 }
+std::string ToString(const ErrorMsgV1& err_msg) { return MakeString(err_msg); }
+std::ostream& operator<<(std::ostream& stream, const ErrorMsgV1& err_msg) {
+  return StreamOpBuilder{stream}
+      .SetSpacer("\n    ")
+      .SetTypeName("ErrorMsgV1")
+      .Build()
+      .AddField("hd", err_msg.hd)
+      .AddField("err", err_msg.err)
+      .Finish();
+}
 std::string ToString(const SymbolMappingMsgV1& symbol_mapping_msg) {
   return MakeString(symbol_mapping_msg);
 }
@@ -259,6 +290,18 @@ std::ostream& operator<<(std::ostream& stream,
       .AddField("stype_out_symbol", symbol_mapping_msg.stype_out_symbol)
       .AddField("start_ts", symbol_mapping_msg.start_ts)
       .AddField("end_ts", symbol_mapping_msg.end_ts)
+      .Finish();
+}
+std::string ToString(const SystemMsgV1& system_msg) {
+  return MakeString(system_msg);
+}
+std::ostream& operator<<(std::ostream& stream, const SystemMsgV1& system_msg) {
+  return StreamOpBuilder{stream}
+      .SetSpacer("\n    ")
+      .SetTypeName("SystemMsgV1")
+      .Build()
+      .AddField("hd", system_msg.hd)
+      .AddField("msg", system_msg.msg)
       .Finish();
 }
 }  // namespace databento

--- a/src/record.cpp
+++ b/src/record.cpp
@@ -467,6 +467,8 @@ std::ostream& operator<<(std::ostream& stream, const ErrorMsg& err_msg) {
       .Build()
       .AddField("hd", err_msg.hd)
       .AddField("err", err_msg.err)
+      .AddField("code", err_msg.code)
+      .AddField("is_last", err_msg.is_last)
       .Finish();
 }
 
@@ -480,6 +482,7 @@ std::ostream& operator<<(std::ostream& stream, const SystemMsg& system_msg) {
       .Build()
       .AddField("hd", system_msg.hd)
       .AddField("msg", system_msg.msg)
+      .AddField("code", system_msg.code)
       .Finish();
 }
 


### PR DESCRIPTION
## 0.15.0 - 2023-01-16
### Breaking changes
- Increased size of `SystemMsg` and `ErrorMsg` to provide better messages from Live
  gateway
  - Increased length of `err` and `msg` fields for more detailed messages
  - Added `is_last` field to `ErrorMsg` to indicate the last error in a chain
  - Added `code` field to `SystemMsg` and `ErrorMsg`, although currently unused
  - Added new `is_last` parameter to `ErrorMsg::new`
  - Decoding these is backwards-compatible and records with longer messages won't be
    sent during the DBN version 2 migration period
  - Renamed previous records to `ErrorMsgV1` and `SystemMsgV1`

