### PR TITLE
Cpp metadata encoder

### DIFF
--- a/cmake/SourcesAndHeaders.cmake
+++ b/cmake/SourcesAndHeaders.cmake
@@ -5,6 +5,7 @@ set(headers
   include/databento/datetime.hpp
   include/databento/dbn.hpp
   include/databento/dbn_decoder.hpp
+  include/databento/dbn_encoder.hpp
   include/databento/dbn_file_store.hpp
   include/databento/enums.hpp
   include/databento/exceptions.hpp
@@ -12,6 +13,7 @@ set(headers
   include/databento/flag_set.hpp
   include/databento/historical.hpp
   include/databento/ireadable.hpp
+  include/databento/iwritable.hpp
   include/databento/live.hpp
   include/databento/live_blocking.hpp
   include/databento/live_threaded.hpp
@@ -40,6 +42,7 @@ set(sources
   src/datetime.cpp
   src/dbn.cpp
   src/dbn_decoder.cpp
+  src/dbn_encoder.cpp
   src/enums.cpp
   src/exceptions.cpp
   src/dbn_file_store.cpp

--- a/include/databento/dbn_encoder.hpp
+++ b/include/databento/dbn_encoder.hpp
@@ -1,10 +1,5 @@
 #pragma once
 
-#include <cstddef>  // size_t
-#include <cstdint>  // uint8_t
-#include <memory>   // unique_ptr
-#include <string>
-
 #include "databento/dbn.hpp"
 #include "databento/iwritable.hpp"
 

--- a/include/databento/dbn_encoder.hpp
+++ b/include/databento/dbn_encoder.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstddef>  // size_t
+#include <cstdint>  // uint8_t
+#include <memory>   // unique_ptr
+#include <string>
+
+#include "databento/dbn.hpp"
+#include "databento/iwritable.hpp"
+
+namespace databento {
+
+class DbnEncoder {
+ public:
+  // Encode metadata from the given buffer.
+  static void EncodeMetadata(const Metadata& buffer, IWritable& writer);
+};
+}  // namespace databento

--- a/include/databento/iwritable.hpp
+++ b/include/databento/iwritable.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cstddef>  // size_t
+#include <cstdint>  // uint8_t
+
+namespace databento {
+// An abstract class for writable objects to allow for runtime polymorphism
+// around DBN encoding.
+class IWritable {
+ public:
+  virtual ~IWritable() = default;
+
+  virtual void Write(const std::uint8_t* buffer, std::uint32_t length) = 0;
+};
+}  // namespace databento

--- a/include/databento/iwritable.hpp
+++ b/include/databento/iwritable.hpp
@@ -10,6 +10,6 @@ class IWritable {
  public:
   virtual ~IWritable() = default;
 
-  virtual void Write(const std::uint8_t* buffer, std::uint32_t length) = 0;
+  virtual void Write(const std::uint8_t* buffer, std::size_t length) = 0;
 };
 }  // namespace databento

--- a/src/dbn_decoder.cpp
+++ b/src/dbn_decoder.cpp
@@ -14,18 +14,11 @@
 #include "databento/exceptions.hpp"
 #include "databento/record.hpp"
 #include "databento/with_ts_out.hpp"
+#include "encode_decode_constants.hpp"
 
 using databento::DbnDecoder;
 
 namespace {
-constexpr std::size_t kMagicSize = 4;
-constexpr std::uint32_t kZstdMagicNumber = 0xFD2FB528;
-constexpr auto kDbnPrefix = "DBN";
-constexpr std::size_t kFixedMetadataLen = 100;
-constexpr std::size_t kDatasetCstrLen = 16;
-constexpr std::size_t kReservedLen = 53;
-constexpr std::size_t kReservedLenV1 = 47;
-constexpr std::size_t kBufferCapacity = 8UL * 1024;
 
 template <typename T>
 T Consume(std::vector<std::uint8_t>::const_iterator& byte_it) {

--- a/src/dbn_encoder.cpp
+++ b/src/dbn_encoder.cpp
@@ -1,0 +1,253 @@
+#include "databento/dbn_encoder.hpp"
+
+#include <algorithm>  // copy
+#include <cstddef>
+#include <cstring>  // strncmp
+#include <limits>
+#include <vector>
+
+#include "databento/compat.hpp"
+#include "databento/constants.hpp"
+#include "databento/datetime.hpp"
+#include "databento/detail/zstd_stream.hpp"
+#include "databento/enums.hpp"
+#include "databento/exceptions.hpp"
+#include "databento/record.hpp"
+
+using databento::DbnEncoder;
+
+namespace {
+constexpr std::size_t kMagicSize = 4;
+constexpr std::uint32_t kZstdMagicNumber = 0xFD2FB528;
+constexpr auto kDbnPrefix = "DBN";
+constexpr std::size_t kFixedMetadataLen = 100;
+constexpr std::size_t kDatasetCstrLen = 16;
+constexpr std::size_t kReservedLen = 53;
+constexpr std::size_t kReservedLenV1 = 47;
+constexpr std::size_t kBufferCapacity = 8UL * 1024;
+
+
+
+constexpr std::uint32_t kSymbolCstrLenV1 = 22;
+constexpr std::uint64_t NULL_RECORD_COUNT = std::numeric_limits<std::uint64_t>::max();
+constexpr std::uint64_t NULL_LIMIT = 0;
+
+}  // namespace
+
+
+static
+std::uint32_t version_symbol_cstr_len(uint8_t version) {
+  if (version < 2) {
+    return kSymbolCstrLenV1;
+  } else {
+    return databento::kSymbolCstrLen;
+  }
+}
+
+static
+std::uint32_t calc_length(const databento::Metadata& metadata) {
+  std::uint32_t symbol_cstr_len = version_symbol_cstr_len(metadata.version);
+  std::uint32_t mapping_interval_len = sizeof(uint32_t) * 2 + symbol_cstr_len;
+  // schema_definition_length, symbols_count, partial_count, not_found_count, mappings_count
+  std::uint32_t var_len_counts_size = sizeof(uint32_t) * 5;
+
+  std::uint32_t c_str_count = metadata.symbols.size() + metadata.partial.size() + metadata.not_found.size();
+
+  std::uint32_t mappings_len = 0;
+  for (const databento::SymbolMapping& item: metadata.mappings) {
+    mappings_len += symbol_cstr_len + sizeof(uint32_t) + item.intervals.size() * mapping_interval_len;
+  }
+
+  return kFixedMetadataLen + var_len_counts_size + c_str_count * symbol_cstr_len + mappings_len;
+}
+
+
+void encode_date(std::uint32_t date, databento::IWritable& writer) {
+  // in c++ the date is already represented as a uint32, so this function doesn't really do anything compared to rust
+  std::uint8_t tmp[sizeof(date)];
+  std::memcpy(tmp, &date, sizeof(date));
+  writer.Write(tmp, sizeof(date));
+}
+
+template <std::uint32_t LEN>
+void encode_fixed_len_cstr(const std::string & str, databento::IWritable& writer) {
+  // check if string is printable (rust checks if it is ascii)
+  if (!std::all_of(str.begin(), str.end(), [](unsigned char ch) {return std::isprint(ch);})) {
+    throw databento::InvalidArgumentError("encode_fixed_len_cstr", "str", "must only contain printable characters");
+  }
+
+  if (str.size() > LEN) {
+    std::string details("value too large to fit, can be at most ");
+    details.append(std::to_string(LEN)).append(", was ").append(std::to_string(str.size()));
+    throw databento::InvalidArgumentError("encode_fixed_len_cstr", "str", std::move(details));
+  }
+
+  std::uint8_t tmp[LEN]{};
+  std::memcpy(tmp, str.data(), str.size());
+  writer.Write(tmp, LEN);
+}
+
+template <std::uint32_t LEN>
+void encode_symbol_mapping(const databento::SymbolMapping & symbol_mapping, databento::IWritable& writer) {
+  encode_fixed_len_cstr<LEN>(symbol_mapping.raw_symbol, writer);
+  // encode interval_count
+  const std::uint32_t length = symbol_mapping.intervals.size(); // assume that this will not overflow
+  std::uint8_t tmp[sizeof(std::uint32_t)];
+  // assuming little endian, it is currently required for the cmake stage to pass
+  std::memcpy(tmp, &length, sizeof(length));
+  writer.Write(tmp, sizeof(length));
+
+  for (const databento::MappingInterval& interval: symbol_mapping.intervals) {
+    encode_date(interval.start_date, writer);
+    encode_date(interval.end_date, writer);
+    encode_fixed_len_cstr<LEN>(interval.symbol, writer);
+  }
+}
+
+static
+std::uint64_t deref_or(const std::uint64_t * ptr, std::uint64_t otherwise) {
+  if (ptr) {
+    return *ptr;
+  } else {
+    return otherwise;
+  }
+}
+
+// future, could use std::optional here if it is OK to depend on it.
+// can the maybe fields ever be not set tho? seems like its not possible in the C++ version
+static
+void encode_range_and_counts(std::uint8_t version,
+                             std::uint64_t start,
+                             const std::uint64_t* maybe_end,
+                             const std::uint64_t* maybe_limit,
+                             databento::IWritable& writer) {
+  std::uint8_t tmp[8]{};
+
+  // assuming little endian, it is currently required for the cmake stage to pass
+  std::memcpy(tmp, &start, sizeof(start));
+  writer.Write(tmp, sizeof(start));
+
+  std::uint64_t tmp_uint64 = deref_or(maybe_end, databento::kUndefTimestamp);
+  // assuming little endian, it is currently required for the cmake stage to pass
+  std::memcpy(tmp, &tmp_uint64, sizeof(tmp_uint64));
+  writer.Write(tmp, sizeof(tmp_uint64));
+
+  tmp_uint64 = deref_or(maybe_limit, NULL_LIMIT);
+  // assuming little endian, it is currently required for the cmake stage to pass
+  std::memcpy(tmp, &tmp_uint64, sizeof(tmp_uint64));
+  writer.Write(tmp, sizeof(tmp_uint64));
+
+  if (version == 1) {
+    tmp_uint64 = NULL_RECORD_COUNT;
+    // assuming little endian, it is currently required for the cmake stage to pass
+    std::memcpy(tmp, &tmp_uint64, sizeof(tmp_uint64));
+    writer.Write(tmp, sizeof(tmp_uint64));
+  }
+}
+
+static
+void encode_repeated_symbol_cstr(const std::uint8_t version, const std::vector<std::string> & symbols, databento::IWritable& writer) {
+  // write number of symbols (length)
+  const std::uint32_t length = symbols.size(); // assume that this will never overflow, who even has more than 4 billion symbols anyway
+  std::uint8_t tmp[sizeof(std::uint32_t)];
+  std::memcpy(tmp, &length, sizeof(length));
+  writer.Write(tmp, sizeof(length));
+
+  if (version == 1) {
+    for (const auto& symbol: symbols) {
+      encode_fixed_len_cstr<kSymbolCstrLenV1>(symbol, writer);
+    }
+  } else {
+    for (const auto& symbol: symbols) {
+      encode_fixed_len_cstr<databento::kSymbolCstrLen>(symbol, writer);
+    }
+  }
+}
+
+static
+void encode_symbol_mappings(const std::uint8_t version, const std::vector<databento::SymbolMapping> & symbol_mappings, databento::IWritable& writer) {
+  // encode mappings_count
+  const std::uint32_t length = symbol_mappings.size(); // assume that this will never overflow, who even has more than 4 billion mappings anyway
+  std::uint8_t tmp[sizeof(std::uint32_t)];
+  std::memcpy(tmp, &length, sizeof(length));
+  writer.Write(tmp, sizeof(length));
+
+  if (version == 1) {
+    for (const auto& mapping: symbol_mappings) {
+      encode_symbol_mapping<kSymbolCstrLenV1>(mapping, writer);
+    }
+  } else {
+    for (const auto& mapping: symbol_mappings) {
+      encode_symbol_mapping<databento::kSymbolCstrLen>(mapping, writer);
+    }
+  }
+}
+
+void DbnEncoder::EncodeMetadata(const Metadata& metadata, IWritable& writer) {
+  // maybe one should serialize to a internal buffer and then write after everything is done?
+  // the writer might be in a strange state if anything fails in the current design
+
+  std::uint8_t tmp[std::max<std::uint32_t>({8, kReservedLen, kReservedLenV1})]{};
+
+  // write the magic number and version
+  std::memcpy(tmp, kDbnPrefix, 3);
+  tmp[3] = std::min<uint8_t>(std::max<uint8_t>(metadata.version, 1), kDbnVersion);
+  writer.Write(tmp, kMagicSize);
+
+  std::uint32_t length = calc_length(metadata);
+  // assuming little endian, it is currently required for the cmake stage to pass
+  std::memcpy(tmp, &length, sizeof(length));
+  writer.Write(tmp, sizeof(length));
+
+  encode_fixed_len_cstr<kDatasetCstrLen>(metadata.dataset, writer);
+
+  // assuming little endian, it is currently required for the cmake stage to pass
+  std::memcpy(tmp, &metadata.schema, sizeof(metadata.schema));
+  writer.Write(tmp, sizeof(metadata.schema));
+
+  std::uint64_t end_count = metadata.end.time_since_epoch().count();
+  encode_range_and_counts(metadata.version, metadata.start.time_since_epoch().count(), &end_count, &metadata.limit, writer);
+
+  auto stype_in = static_cast<std::uint8_t>(metadata.stype_in);
+  writer.Write(&stype_in, sizeof(stype_in));
+
+  auto stype_out = static_cast<std::uint8_t>(metadata.stype_out);
+  writer.Write(&stype_out, sizeof(stype_out));
+
+  auto ts_out = static_cast<std::uint8_t>(metadata.ts_out);
+  writer.Write(&ts_out, sizeof(ts_out));
+
+  if (metadata.version > 1) {
+    if (metadata.symbol_cstr_len > std::numeric_limits<std::uint16_t>::max()) {
+      throw databento::InvalidArgumentError("EncodeMetadata", "symbol_cstr_len", "value too large to fit in uint16");
+    }
+
+    std::uint16_t symbol_cstr_len = metadata.symbol_cstr_len;
+    // assuming little endian, it is currently required for the cmake stage to pass
+    std::memcpy(tmp, &symbol_cstr_len, sizeof(symbol_cstr_len));
+    writer.Write(tmp, sizeof(symbol_cstr_len));
+  }
+
+  // padding
+  if (metadata.version == 1) {
+    memset(tmp, 0, kReservedLenV1);
+    writer.Write(tmp, kReservedLenV1);
+  } else {
+    memset(tmp, 0, kReservedLen);
+    writer.Write(tmp, kReservedLen);
+  }
+
+  // schema_definition_length, not supported by DBN v1 nor v2
+  const std::uint32_t schema_definition_length = 0;
+  std::memcpy(tmp, &schema_definition_length, sizeof(schema_definition_length));
+  writer.Write(tmp, sizeof(schema_definition_length));
+
+
+  encode_repeated_symbol_cstr(metadata.version, metadata.symbols, writer);
+  encode_repeated_symbol_cstr(metadata.version, metadata.partial, writer);
+  encode_repeated_symbol_cstr(metadata.version, metadata.not_found, writer);
+  encode_symbol_mappings(metadata.version, metadata.mappings, writer);
+}
+
+
+

--- a/src/dbn_encoder.cpp
+++ b/src/dbn_encoder.cpp
@@ -13,29 +13,9 @@
 #include "databento/enums.hpp"
 #include "databento/exceptions.hpp"
 #include "databento/record.hpp"
+#include "encode_decode_constants.hpp"
 
 using databento::DbnEncoder;
-
-namespace {
-constexpr std::size_t kMagicSize = 4;
-constexpr std::uint32_t kZstdMagicNumber = 0xFD2FB528;
-constexpr auto kDbnPrefix = "DBN";
-constexpr std::size_t kFixedMetadataLen = 100;
-constexpr std::size_t kDatasetCstrLen = 16;
-constexpr std::size_t kReservedLen = 53;
-constexpr std::size_t kReservedLenV1 = 47;
-constexpr std::size_t kBufferCapacity = 8UL * 1024;
-
-
-
-constexpr std::uint32_t kSymbolCstrLenV1 = 22;
-constexpr std::uint64_t NULL_RECORD_COUNT = std::numeric_limits<std::uint64_t>::max();
-constexpr std::uint64_t NULL_LIMIT = 0;
-constexpr std::uint16_t NULL_SCHEMA = std::numeric_limits<std::uint16_t>::max();
-constexpr std::uint8_t NULL_STYPE = std::numeric_limits<std::uint8_t>::max();
-
-}  // namespace
-
 
 static
 std::uint32_t version_symbol_cstr_len(uint8_t version) {

--- a/src/dbn_encoder.cpp
+++ b/src/dbn_encoder.cpp
@@ -31,6 +31,7 @@ constexpr std::size_t kBufferCapacity = 8UL * 1024;
 constexpr std::uint32_t kSymbolCstrLenV1 = 22;
 constexpr std::uint64_t NULL_RECORD_COUNT = std::numeric_limits<std::uint64_t>::max();
 constexpr std::uint64_t NULL_LIMIT = 0;
+constexpr std::uint8_t NULL_STYPE = std::numeric_limits<std::uint8_t>::max();
 
 }  // namespace
 
@@ -208,7 +209,12 @@ void DbnEncoder::EncodeMetadata(const Metadata& metadata, IWritable& writer) {
   std::uint64_t end_count = metadata.end.time_since_epoch().count();
   encode_range_and_counts(metadata.version, metadata.start.time_since_epoch().count(), &end_count, &metadata.limit, writer);
 
-  auto stype_in = static_cast<std::uint8_t>(metadata.stype_in);
+  std::uint8_t stype_in;
+  if (metadata.has_mixed_stype_in) {
+    stype_in = NULL_STYPE;
+  } else {
+    stype_in = static_cast<std::uint8_t>(metadata.stype_in);
+  }
   writer.Write(&stype_in, sizeof(stype_in));
 
   auto stype_out = static_cast<std::uint8_t>(metadata.stype_out);

--- a/src/encode_decode_constants.hpp
+++ b/src/encode_decode_constants.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cstdint>
+#include <limits>
+
+constexpr std::size_t kMagicSize = 4;
+constexpr std::uint32_t kZstdMagicNumber = 0xFD2FB528;
+constexpr auto kDbnPrefix = "DBN";
+constexpr std::size_t kFixedMetadataLen = 100;
+constexpr std::size_t kDatasetCstrLen = 16;
+constexpr std::size_t kReservedLen = 53;
+constexpr std::size_t kReservedLenV1 = 47;
+constexpr std::size_t kBufferCapacity = 8UL * 1024;
+
+
+
+constexpr std::uint32_t kSymbolCstrLenV1 = 22;
+constexpr std::uint64_t NULL_RECORD_COUNT = std::numeric_limits<std::uint64_t>::max();
+constexpr std::uint64_t NULL_LIMIT = 0;
+constexpr std::uint16_t NULL_SCHEMA = std::numeric_limits<std::uint16_t>::max();
+constexpr std::uint8_t NULL_STYPE = std::numeric_limits<std::uint8_t>::max();
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ set(
   src/batch_tests.cpp
   src/datetime_tests.cpp
   src/dbn_decoder_tests.cpp
+  src/dbn_encoder_tests.cpp
   src/dbn_tests.cpp
   src/file_stream_tests.cpp
   src/flag_set_tests.cpp

--- a/test/src/dbn_encoder_tests.cpp
+++ b/test/src/dbn_encoder_tests.cpp
@@ -65,7 +65,7 @@ class DbnEncoderTests : public testing::Test {
 
 struct FakeWritable : IWritable {
   std::vector<std::uint8_t> written_bytes;
-  void Write(const std::uint8_t* buffer, std::uint32_t length) override {
+  void Write(const std::uint8_t* buffer, std::size_t length) override {
     written_bytes.insert(written_bytes.end(), buffer, buffer + length);
   }
 };

--- a/test/src/dbn_encoder_tests.cpp
+++ b/test/src/dbn_encoder_tests.cpp
@@ -1,0 +1,106 @@
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <fstream>  // ifstream
+#include <ios>      // streamsize, ios::binary, ios::ate
+#include <memory>
+
+#include "databento/compat.hpp"
+#include "databento/constants.hpp"
+#include "databento/dbn.hpp"
+#include "databento/dbn_decoder.hpp"
+#include "databento/dbn_encoder.hpp"
+#include "databento/detail/file_stream.hpp"
+#include "databento/detail/scoped_thread.hpp"
+#include "databento/detail/shared_channel.hpp"
+#include "databento/enums.hpp"
+#include "databento/exceptions.hpp"
+#include "databento/ireadable.hpp"
+#include "databento/record.hpp"
+
+namespace databento {
+namespace test {
+class DbnEncoderTests : public testing::Test {
+ public:
+  detail::SharedChannel channel_;
+  std::unique_ptr<DbnDecoder> file_target_;
+  std::unique_ptr<DbnDecoder> channel_target_;
+  detail::ScopedThread write_thread_;
+
+  void ReadFromFile(const std::string& schema_str, const std::string& extension,
+                    std::uint8_t version) {
+    ReadFromFile(schema_str, extension, version, VersionUpgradePolicy::AsIs);
+  }
+
+  void ReadFromFile(const std::string& schema_str, const std::string& extension,
+                    std::uint8_t version, VersionUpgradePolicy upgrade_policy) {
+    const char* version_str = version == 1 ? ".v1" : "";
+    const std::string file_path = TEST_BUILD_DIR "/data/test_data." +
+                                  schema_str + version_str + extension;
+    // Channel setup
+    write_thread_ = detail::ScopedThread{[this, file_path] {
+      std::ifstream input_file{file_path, std::ios::binary | std::ios::ate};
+      ASSERT_TRUE(input_file.good());
+      const auto size = static_cast<std::size_t>(input_file.tellg());
+      input_file.seekg(0, std::ios::beg);
+      std::vector<char> buffer(size);
+      input_file.read(buffer.data(), static_cast<std::streamsize>(size));
+      ASSERT_EQ(input_file.gcount(), size);
+      channel_.Write(reinterpret_cast<const std::uint8_t*>(buffer.data()),
+                     size);
+      channel_.Finish();
+    }};
+    channel_target_.reset(new DbnDecoder{
+      std::unique_ptr<IReadable>{new detail::SharedChannel{channel_}},
+      upgrade_policy});
+    // File setup
+    file_target_.reset(new DbnDecoder{
+      std::unique_ptr<IReadable>{new detail::FileStream{file_path}},
+      upgrade_policy});
+  }
+};
+
+
+struct FakeWritable : IWritable {
+  std::vector<std::uint8_t> written_bytes;
+  void Write(const std::uint8_t* buffer, std::uint32_t length) override {
+    written_bytes.insert(written_bytes.end(), buffer, buffer + length);
+  }
+};
+
+struct FakeReadable : IReadable {
+  std::vector<std::uint8_t> bytes;
+  void ReadExact(std::uint8_t* buffer, std::size_t length) override {
+    std::memmove(buffer, bytes.data(), length);
+    bytes.erase(bytes.begin(), bytes.begin()+length);
+  }
+
+  std::size_t ReadSome(std::uint8_t* buffer, std::size_t max_length) override {
+    std::size_t  len = std::min(max_length, bytes.size());
+    std::memmove(buffer, bytes.data(), len);
+    bytes.erase(bytes.begin(), bytes.begin()+len);
+    return len;
+  }
+};
+
+TEST_F(DbnEncoderTests, TestDecodeDefinitionUpgrade) {
+  ReadFromFile("definition", ".dbn", 1, VersionUpgradePolicy::Upgrade);
+
+  FakeWritable fake_writable;
+
+  const Metadata ch_metadata = channel_target_->DecodeMetadata();
+  DbnEncoder::EncodeMetadata(ch_metadata, fake_writable);
+
+  auto fake_readable = std::make_unique<FakeReadable>();
+  fake_readable->bytes = fake_writable.written_bytes;
+  DbnDecoder decoder(std::move(fake_readable), databento::VersionUpgradePolicy::AsIs);
+
+  Metadata decoded = decoder.DecodeMetadata();
+
+  EXPECT_EQ(ch_metadata, decoded);
+}
+
+}  // namespace test
+}  // namespace databento


### PR DESCRIPTION
# Pull Request

Add metadata encoder to C++.
It is currently next to the decoder class. It does not use any persistent state so does not really need to be instantiated.

Effort was made to stick close to the Rust reference implementation. Which at the time included having the string size bug which was later fixed in Rust in this commit https://github.com/databento/dbn/commit/aede39b73c9858eb95ce2fd678ef0378ec38bc9e
this PR does not initially contain the corresponding update.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How has this change been tested?
1 unit test.

and 

wrote metadata to a file and read it back from python, seems fine bar potential lack of DBN understanding from the humans doing the testing. seems fine.
