### PR TITLE
Use strnlen to upper-bound the length of the dataset name coming from the file

### DIFF
--- a/src/dbn_decoder.cpp
+++ b/src/dbn_decoder.cpp
@@ -106,7 +106,8 @@ databento::Metadata DbnDecoder::DecodeMetadataFields(
         std::to_string(res.version)};
   }
   auto read_buffer_it = buffer.cbegin();
-  res.dataset = std::string{Consume(read_buffer_it, kDatasetCstrLen)};
+  const auto dataset_cstr = Consume(read_buffer_it, kDatasetCstrLen);
+  res.dataset = std::string{dataset_cstr, strnlen(dataset_cstr, kDatasetCstrLen)};
   const auto raw_schema = Consume<std::uint16_t>(read_buffer_it);
   if (raw_schema == std::numeric_limits<std::uint16_t>::max()) {
     res.has_mixed_schema = true;


### PR DESCRIPTION
# Pull Request

`strnlen` guarantees that a corrupted or maliciously crafted file doesn't cause the `std::string` to read past the end of the buffer looking for a `\0` terminator.

## Type of change

Hardening of the file/response parser.

## How has this change been tested?

Existing tests.