### PR TITLE
VER: Release 0.16.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,7 +54,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install dependencies
         run: brew install cmake cppcheck googletest openssl@3 ninja zstd
       # Don't enable clang-tidy on macOS because it's incredibly slow
@@ -77,9 +77,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-vcpkg
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,8 +27,8 @@ jobs:
           cd cppcheck
           cmake -S. -B build \
             -DCMAKE_BUILD_TYPE=Release \
-            -DUSE_MATCHCOMPILER=1 \
-            -DHAVE_RULES=1
+            -DUSE_MATCHCOMPILER=ON \
+            -DHAVE_RULES=ON
           cmake --build build --config Release
           sudo cmake --install build --prefix /usr
       - name: Install gtest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install dependencies
         # pcre is a dependency of cppcheck
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
           cd cppcheck
           cmake -S. -B build \
             -DCMAKE_BUILD_TYPE=Release \
-            -DUSE_MATCHCOMPILER=ON \
+            -DUSE_MATCHCOMPILER=On \
             -DHAVE_RULES=ON
           cmake --build build --config Release
           sudo cmake --install build --prefix /usr

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Enhancements
 - Added new publisher values for consolidated DBEQ.MAX
+- Added constructor to `WithTsOut` that updates `length` to the correct value to account
+  for the extra 8 bytes
 
 ### Breaking changes
 - Changed default `upgrade_policy` to `Upgrade` so by default the primary record types
@@ -11,6 +13,9 @@
 - Renamed `dummy` field in `ImbalanceMsg` and `StatMsg` to `reserved`
 
 ### Bug fixes
+- Fixed handling of `ts_out` when decoding DBNv1 and upgrading to version 2
+- Fixed missing logic to upgrade `ErrorMsgV1` and `SystemMsgV1` when decoding DBN with
+  `VersionUpgradePolicy::Upgrade`
 - Added missing `StatType::Vwap` variant used in the ICE datasets
 - Added missing `ToString` and `operator<<` handling for `StatType::ClosePrice` and
   `StatType::NetChange`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.15.0 - 2023-01-16
+## 0.15.0 - 2024-01-16
 
 ### Breaking changes
 - Increased size of `SystemMsg` and `ErrorMsg` to provide better messages from Live

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## 0.16.0 - TBD
 
+### Enhancements
+- Added new publisher values for consolidated DBEQ.MAX
+
 ### Breaking changes
 - Changed default `upgrade_policy` to `Upgrade` so by default the primary record types
   can always be used
 
-##### Bug fixes
+### Bug fixes
 - Added missing `StatType::Vwap` variant used in the ICE datasets
 - Added missing `ToString` and `operator<<` handling for `StatType::ClosePrice` and
   `StatType::NetChange`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added missing `StatType::Vwap` variant used in the ICE datasets
 - Added missing `ToString` and `operator<<` handling for `StatType::ClosePrice` and
   `StatType::NetChange`
+- Fixed potential for invalid reads when decoding C strings in `DbnDecoder`
 
 ## 0.15.0 - 2024-01-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.15.0 - 2024-01-16
 
 ### Breaking changes
+
 - Increased size of `SystemMsg` and `ErrorMsg` to provide better messages from Live
   gateway
   - Increased length of `err` and `msg` fields for more detailed messages
@@ -16,10 +17,12 @@
 ## 0.14.1 - 2023-12-18
 
 ### Enhancements
+
 - Added `PitSymbolMap` helper for keeping track of symbology mappings in Live
 - Added new publisher value for OPRA MIAX Sapphire
 
 ### Bug fixes
+
 - Fixed misaligned read undefined behavior when decoding records
 
 ## 0.14.0 - 2023-11-23
@@ -35,6 +38,7 @@ On a future date, the Databento live and historical APIs will stop serving DBN v
 This release is fully compatible with both DBN v1 and v2, and so should be seamless for most users.
 
 ### Enhancements
+
 - Added support for DBN encoding version 2 (DBNv2), affecting `SymbolMappingMsg`,
   `InstrumentDefMsg`, and `Metadata`
   - Version 1 structs can be converted to version 2 structs with the `ToV2()` method
@@ -51,10 +55,11 @@ This release is fully compatible with both DBN v1 and v2, and so should be seaml
   length of fixed-length symbol strings in different DBN versions
 - Added new publisher values in preparation for IFEU.IMPACT and NDEX.IMPACT datasets
 - Added new publisher values for consolidated DBEQ.BASIC and DBEQ.PLUS
-- Added `kMaxRecordLen` constant for the the length of the largest record type
+- Added `kMaxRecordLen` constant for the length of the largest record type
 - Added ability to convert `FlagSet` to underlying representation
 
 ### Breaking changes
+
 - The old `InstrumentDefMsg` is now `InstrumentDefMsgV1` in `compat.hpp`
 - The old `SymbolMappingMsg` is now `SymbolMappingMsgV1` in `compat.hpp`
 - Converted the following enums to enum classes to allow safely adding new variants:
@@ -65,7 +70,9 @@ This release is fully compatible with both DBN v1 and v2, and so should be seaml
 - Removed deprecated `SecurityUpdateAction::Invalid` variant
 
 ## 0.13.1 - 2023-10-23
+
 ### Enhancements
+
 - Added new publisher values in preparation for DBEQ.PLUS
 - Added `ToIso8601` for `UnixNanos` for converting to human-readable ISO8601 datetime
   string
@@ -73,13 +80,15 @@ This release is fully compatible with both DBN v1 and v2, and so should be seaml
 - Added flag `kTob` for top-of-book messages
 
 ## 0.13.0 - 2023-09-21
+
 ### Enhancements
+
 - Added `pretty_px` option for `BatchSubmitJob`, which formats prices to the correct
   scale using the fixed-precision scalar 1e-9 (available for CSV and JSON text
   encodings)
 - Added `pretty_ts` option for `BatchSubmitJob`, which formats timestamps as ISO 8601
   strings (available for CSV and JSON text encodings)
-- Added `map_symbols` option to `BatchSubmitJob`, which appends appends the raw symbol
+- Added `map_symbols` option to `BatchSubmitJob`, which appends the raw symbol
   to every record (available for CSV and JSON text encodings) reducing the need to look
   at the `symbology.json` file
 - Added `split_symbols` option for `BatchSubmitJob`, which will split files by raw symbol
@@ -90,15 +99,19 @@ This release is fully compatible with both DBN v1 and v2, and so should be seaml
 - Added `ClosePrice` and `NetChange` `StatType`s used in the `OPRA.PILLAR` dataset
 
 ### Breaking changes
+
 - Remove `default_value` parameter from `Historical::SymbologyResolve`
 
 ## 0.12.1 - 2023-08-25
+
 ### Bug fixes
+
 - Fixed typo in `BATY.PITCH.BATY` publisher
 
 ## 0.12.0 - 2023-08-24
 
 ##### Enhancements
+
 - Added the `Publisher`, `Venue`, and `Dataset` enums
 - Added `Publisher` getters to `Record` and `RecordHeader` to convert the
   `publisher_id` to its enum
@@ -106,11 +119,13 @@ This release is fully compatible with both DBN v1 and v2, and so should be seaml
 ## 0.11.0 - 2023-08-10
 
 #### Enhancements
+
 - Added `raw_instrument_id` to definition schema
 - Added `operator==` and `operator!=` implementations for `DatasetConditionDetail` and
   `DatasetRange`
 
 #### Breaking changes
+
 - Changed `MetadataListPublishers` to return a `vector<PublisherDetail>`
 - `MetadataListFields`:
   - Changed return type to `vector<FieldDetail>`
@@ -122,6 +137,7 @@ This release is fully compatible with both DBN v1 and v2, and so should be seaml
   - Removed `mode` and `schema` parameters
 
 #### Bug fixes
+
 - Fixed installation of `nlohmann_json` when using bundled version
 - Added missing `operator!=` implementations for `Metadata`, `MappingInterval`, and
   `SymbolMapping`
@@ -129,6 +145,7 @@ This release is fully compatible with both DBN v1 and v2, and so should be seaml
 ## 0.10.0 - 2023-07-20
 
 #### Enhancements
+
 - Added preliminary support for Windows
 - Added `LiveThreaded::BlockForStop` to make it easier to wait for one or more records
   before closing the session
@@ -139,20 +156,24 @@ This release is fully compatible with both DBN v1 and v2, and so should be seaml
   length limit
 
 #### Breaking changes
+
 - Changed size-related fields and `limit` parameters to use `std::uint64_t` for consistency
   across architectures
 
 #### Bug fixes
+
 - Removed usage of non-portable `__PRETTY_FUNCTION__`
 
 ## 0.9.1 - 2023-07-11
 
 #### Enhancements
+
 - Added constants for dataset codes for Databento Equity Basic and OPRA Pillar
 - Added `const char*` getters to records for fixed-length `char` arrays
 - Added `RType` getter to `Record`
 
 #### Bug fixes
+
 - Added batching for live subscriptions to avoid hitting max message length
 - Fixed bug in Zstd decompression
 - Fixed `Historical::BatchDownload` truncating file before writing each chunk
@@ -160,6 +181,7 @@ This release is fully compatible with both DBN v1 and v2, and so should be seaml
 ## 0.9.0 - 2023-06-13
 
 #### Enhancements
+
 - Added `Reconnect` methods to `LiveBlocking` and `LiveThreaded`
 - Added optional `exception_callback` argument to `LiveThreaded::Start` to improve
   error handling options
@@ -168,17 +190,21 @@ This release is fully compatible with both DBN v1 and v2, and so should be seaml
 - Relaxed 10 minute minimum request time range restriction
 
 #### Breaking changes
+
 - Changed `use_ts_out` default to `false`
 
 #### Bug fixes
+
 - Fixed missing definition for `operator==` for `ImbalanceMsg`
 
 ## 0.8.0 - 2023-05-16
 
 #### Enhancements
+
 - Changed `end` and `end_date` to optional to support new forward-fill behaviour
 
 #### Breaking changes
+
 - Renamed `booklevel` MBP field to `levels` for brevity and consistent naming
 - Removed `open_interest_qty` and `cleared_volume` fields from definition schema
   that were always unset
@@ -186,6 +212,7 @@ This release is fully compatible with both DBN v1 and v2, and so should be seaml
 ## 0.7.0 - 2023-04-28
 
 #### Enhancements
+
 - Added initial support for live data with `LiveBlocking` and `LiveThreaded` clients
 - Added support for statistics schema
 - Added `SystemMsg` and `ErrorMsg` records for use in live data
@@ -203,6 +230,7 @@ This release is fully compatible with both DBN v1 and v2, and so should be seaml
 - Added optional `compression` parameter to `BatchSubmitJob`
 
 #### Breaking changes
+
 - Removed `related` and `related_security_id` from `InstrumentDefMsg`
 - Renamed `BatchJob.cost` to `cost_usd` and value now expressed as US dollars
 - Renamed `SType::ProductId` to `SType::InstrumentId` and `SType::Native` to
@@ -214,9 +242,11 @@ This release is fully compatible with both DBN v1 and v2, and so should be seaml
 - Changed some fields to enums in `InstrumentDefMsg`
 
 #### Deprecations
+
 - Deprecated `SType::Smart` to split into `SType::Parent` and `SType::Continuous`
 
 #### Bug fixes
+
 - Fixed parsing of `BatchSubmitJob` response
 - Fixed invalid read in `DbnDecoder`
 - Fixed memory leak in `TryCreateDir`
@@ -224,28 +254,34 @@ This release is fully compatible with both DBN v1 and v2, and so should be seaml
 ## 0.6.1 - 2023-03-28
 
 #### Breaking changes
+
 - Removed usage of unreliable `std::ifstream::readsome`
 
 #### Bug fixes
+
 - Fixed Zstd decoding of files with multiple frames
 
 ## 0.6.0 - 2023-03-24
 
 #### Enhancements
+
 - Added support for imbalance schema
 - Added support for decoding `ts_out` field
 - Added flags `kSnapshot` and `kMaybeBadBook`
 
 #### Breaking changes
+
 - Removed `record_count` from `Metadata`
 - Changed `Historical::BatchDownload` to return the paths of the downloaded files
 
 ## 0.5.0 - 2023-03-13
 
 #### Enhancements
+
 - Added `Historical::MetadataGetDatasetRange`
 
 #### Breaking changes
+
 - Changed `MetadataGetDatasetCondition` to return `vector<DatasetConditionDetail>`
 - Removed `MetadataListCompressions` (redundant with docs)
 - Removed `MetadataListEncodings` (redundant with docs)
@@ -268,6 +304,7 @@ This release is fully compatible with both DBN v1 and v2, and so should be seaml
 - Disabled unit testing by default
 
 #### Breaking changes
+
 - Removed `is_full_universe` and `is_example` fields from `BatchJob`
 - Refactored rtypes
   - Introduced separate rtypes for each OHLCV schema
@@ -277,22 +314,26 @@ This release is fully compatible with both DBN v1 and v2, and so should be seaml
 - Changed `kAllSymbols` representation
 
 #### Bug fixes
+
 - Fixed usage of as a system library
 
 ## 0.3.0 - 2023-01-06
 
 #### Enhancements
+
 - Added support for definition schema
 - Added option for CMake to download gtest
 - Updated `Flag` enum
 
 #### Breaking changes
+
 - Standardized getter method names to pascal case
 - Renamed `is_full_book` to `is_full_universe`
 - Renamed `TickMsg` to `MboMsg`
 - Changed `flags` fields to unsigned
 
 #### Bug fixes
+
 - Fixed cancellation in `Historical::TimeseriesStream`
 - Fixed race condition in `Historical::TimeseriesStream` exception handling
 - Fixed gtest linker error on macOS
@@ -300,11 +341,14 @@ This release is fully compatible with both DBN v1 and v2, and so should be seaml
 ## 0.2.0 - 2022-12-01
 
 #### Enhancements
+
 - Added `Historical::MetadataGetDatasetCondition`
 - Improved Zstd CMake integration
 
 #### Bug fixes
+
 - Fixed requesting all symbols for a dataset
 
 ## 0.1.0 - 2022-11-07
+
 - Initial release with support for historical data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
-## 0.16.0 - TBD
+## 0.16.0 - 2024-03-01
 
 ### Enhancements
 - Added new publisher values for consolidated DBEQ.MAX
 - Added constructor to `WithTsOut` that updates `length` to the correct value to account
   for the extra 8 bytes
+- Upgrade default cpp-httplib version to 0.14.3 (last to still support OpenSSL 1.1)
+- Upgrade default nlohmann_json version to 3.11.3
 
 ### Breaking changes
 - Changed default `upgrade_policy` to `Upgrade` so by default the primary record types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Breaking changes
 - Changed default `upgrade_policy` to `Upgrade` so by default the primary record types
   can always be used
+- Renamed `dummy` field in `ImbalanceMsg` and `StatMsg` to `reserved`
 
 ### Bug fixes
 - Added missing `StatType::Vwap` variant used in the ICE datasets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 - Changed default `upgrade_policy` to `Upgrade` so by default the primary record types
   can always be used
 
+##### Bug fixes
+- Added missing `StatType::Vwap` variant used in the ICE datasets
+- Added missing `ToString` and `operator<<` handling for `StatType::ClosePrice` and
+  `StatType::NetChange`
+
 ## 0.15.0 - 2024-01-16
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.16.0 - TBD
+
+### Breaking changes
+- Changed default `upgrade_policy` to `Upgrade` so by default the primary record types
+  can always be used
+
 ## 0.15.0 - 2024-01-16
 
 ### Breaking changes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.14)
 # Project details
 #
 
-project("databento" VERSION 0.15.0 LANGUAGES CXX)
+project("databento" VERSION 0.16.0 LANGUAGES CXX)
 string(TOUPPER ${PROJECT_NAME} PROJECT_NAME_UPPERCASE)
 
 #
@@ -121,7 +121,7 @@ include(FetchContent)
 if(${PROJECT_NAME_UPPERCASE}_USE_EXTERNAL_JSON)
   find_package(nlohmann_json REQUIRED)
 else()
-  set(json_version 3.11.2)
+  set(json_version 3.11.3)
   # Required to correctly install nlohmann_json
   set(JSON_Install ON)
   if(CMAKE_VERSION VERSION_LESS 3.24)
@@ -145,7 +145,7 @@ endif()
 if(${PROJECT_NAME_UPPERCASE}_USE_EXTERNAL_HTTPLIB)
   find_package(httplib REQUIRED)
 else()
-  set(httplib_version 0.13.1)
+  set(httplib_version 0.14.3)
   if(CMAKE_VERSION VERSION_LESS 3.24)
     FetchContent_Declare(
       httplib

--- a/example/live/simple.cpp
+++ b/example/live/simple.cpp
@@ -23,7 +23,6 @@ int main() {
                     .SetLogReceiver(log_receiver.get())
                     .SetKeyFromEnv()
                     .SetDataset(databento::dataset::kGlbxMdp3)
-                    .SetUpgradePolicy(databento::VersionUpgradePolicy::Upgrade)
                     .BuildThreaded();
 
   // Set up signal handler for Ctrl+C

--- a/include/databento/constants.hpp
+++ b/include/databento/constants.hpp
@@ -24,6 +24,8 @@ static constexpr auto kUndefTimestamp =
 static constexpr auto kDbnVersion = 2;
 // The length of fixed-length symbol strings.
 static constexpr auto kSymbolCstrLen = 71;
+// The multiplier for converting the `length` field in `RecordHeader` to bytes.
+static constexpr std::size_t kRecordHeaderLengthMultiplier = 4;
 
 // This is not necessarily a comprehensive list of available datasets. Please
 // use `Historical.MetadataListDatasets` to retrieve an up-to-date list.

--- a/include/databento/dbn_decoder.hpp
+++ b/include/databento/dbn_decoder.hpp
@@ -14,8 +14,7 @@
 
 namespace databento {
 // DBN decoder. Set upgrade_policy to control how DBN version 1 data should be
-// handled. Currently it defaults to returning this data as-is, but this default
-// will change in a future version.
+// handled. Defaults to upgrading DBNv1 data to version 2 (the current version).
 class DbnDecoder {
  public:
   explicit DbnDecoder(detail::SharedChannel channel);

--- a/include/databento/dbn_decoder.hpp
+++ b/include/databento/dbn_decoder.hpp
@@ -33,7 +33,7 @@ class DbnDecoder {
   // given version and upgrade policy. If an upgrade is applied,
   // compat_buffer is modified.
   static Record DecodeRecordCompat(
-      std::uint8_t version, VersionUpgradePolicy upgrade_policy,
+      std::uint8_t version, VersionUpgradePolicy upgrade_policy, bool ts_out,
       std::array<std::uint8_t, kMaxRecordLen>* compat_buffer, Record rec);
 
   // Should be called exactly once.
@@ -64,6 +64,7 @@ class DbnDecoder {
 
   std::uint8_t version_{};
   VersionUpgradePolicy upgrade_policy_;
+  bool ts_out_{};
   std::unique_ptr<IReadable> input_;
   std::vector<std::uint8_t> read_buffer_;
   std::size_t buffer_idx_{};

--- a/include/databento/enums.hpp
+++ b/include/databento/enums.hpp
@@ -254,6 +254,10 @@ enum StatType : std::uint16_t {
   // The change in price from the close price of the previous trading session to
   // the most recent trading session. `price` will be set.
   NetChange = 12,
+  /// The volume-weighted average price (VWAP) during the trading session.
+  /// `price` will be set to the VWAP while `quantity` will be the traded
+  /// volume.
+  Vwap = 13,
 };
 }  // namespace stat_type
 using stat_type::StatType;

--- a/include/databento/live.hpp
+++ b/include/databento/live.hpp
@@ -26,8 +26,7 @@ class LiveBuilder {
   // Whether to append the gateway send timestamp after each DBN message.
   LiveBuilder& SetSendTsOut(bool send_ts_out);
   // Set the version upgrade policy for when receiving DBN data from a prior
-  // version. In this version defaults to as-is, but in a future version
-  // will default to upgrading it to DBNv2.
+  // version. Defaults to upgrading to DBNv2 (if not already).
   LiveBuilder& SetUpgradePolicy(VersionUpgradePolicy upgrade_policy);
   // Sets the receiver of the logs to be used by the client.
   LiveBuilder& SetLogReceiver(ILogReceiver* log_receiver);
@@ -45,6 +44,6 @@ class LiveBuilder {
   std::string key_;
   std::string dataset_;
   bool send_ts_out_{false};
-  VersionUpgradePolicy upgrade_policy_{VersionUpgradePolicy::AsIs};
+  VersionUpgradePolicy upgrade_policy_{VersionUpgradePolicy::Upgrade};
 };
 }  // namespace databento

--- a/include/databento/publishers.hpp
+++ b/include/databento/publishers.hpp
@@ -89,6 +89,8 @@ enum class Venue : std::uint16_t {
   Dbeq = 40,
   // MIAX Sapphire
   Sphr = 41,
+  // Long-Term Stock Exchange, Inc.
+  Ltse = 42,
 };
 
 // A source of data.
@@ -151,6 +153,8 @@ enum class Dataset : std::uint16_t {
   IfeuImpact = 28,
   // ICE Endex iMpact
   NdexImpact = 29,
+  // Databento Equities Max
+  DbeqMax = 30,
 };
 
 // A specific Venue from a specific data source.
@@ -277,6 +281,44 @@ enum class Publisher : std::uint16_t {
   DbeqPlusDbeq = 60,
   // OPRA - MIAX Sapphire
   OpraPillarSphr = 61,
+  // DBEQ Max - NYSE Chicago
+  DbeqMaxXchi = 62,
+  // DBEQ Max - NYSE National
+  DbeqMaxXcis = 63,
+  // DBEQ Max - IEX
+  DbeqMaxIexg = 64,
+  // DBEQ Max - MIAX Pearl
+  DbeqMaxEprl = 65,
+  // DBEQ Max - Nasdaq
+  DbeqMaxXnas = 66,
+  // DBEQ Max - NYSE
+  DbeqMaxXnys = 67,
+  // DBEQ Max - FINRA/NYSE TRF
+  DbeqMaxFinn = 68,
+  // DBEQ Max - FINRA/Nasdaq TRF Carteret
+  DbeqMaxFiny = 69,
+  // DBEQ Max - FINRA/Nasdaq TRF Chicago
+  DbeqMaxFinc = 70,
+  // DBEQ Max - CBOE BZX
+  DbeqMaxBats = 71,
+  // DBEQ Max - CBOE BYX
+  DbeqMaxBaty = 72,
+  // DBEQ Max - CBOE EDGA
+  DbeqMaxEdga = 73,
+  // DBEQ Max - CBOE EDGX
+  DbeqMaxEdgx = 74,
+  // DBEQ Max - Nasdaq BX
+  DbeqMaxXbos = 75,
+  // DBEQ Max - Nasdaq PSX
+  DbeqMaxXpsx = 76,
+  // DBEQ Max - MEMX
+  DbeqMaxMemx = 77,
+  // DBEQ Max - NYSE American
+  DbeqMaxXase = 78,
+  // DBEQ Max - NYSE Arca
+  DbeqMaxArcx = 79,
+  // DBEQ Max - Long-Term Stock Exchange
+  DbeqMaxLtse = 80,
 };
 
 // Get a Publisher's Venue.

--- a/include/databento/record.hpp
+++ b/include/databento/record.hpp
@@ -299,7 +299,7 @@ struct ImbalanceMsg {
   Side unpaired_side;
   char significant_imbalance;
   // padding for alignment
-  std::array<char, 1> dummy;
+  std::array<char, 1> reserved;
 };
 static_assert(sizeof(ImbalanceMsg) == 112, "ImbalanceMsg size must match Rust");
 static_assert(alignof(ImbalanceMsg) == 8, "Must have 8-byte alignment");
@@ -323,7 +323,7 @@ struct StatMsg {
   std::uint16_t channel_id;
   StatUpdateAction update_action;
   std::uint8_t stat_flags;
-  std::array<char, 6> dummy;
+  std::array<char, 6> reserved;
 };
 static_assert(sizeof(StatMsg) == 64, "StatMsg size must match Rust");
 static_assert(alignof(StatMsg) == 8, "Must have 8-byte alignment");

--- a/include/databento/record.hpp
+++ b/include/databento/record.hpp
@@ -13,11 +13,13 @@
 #include "databento/enums.hpp"
 #include "databento/flag_set.hpp"    // FlagSet
 #include "databento/publishers.hpp"  // Publisher
+#include "databento/with_ts_out.hpp"
 
 namespace databento {
 // Common data for all Databento Records.
 struct RecordHeader {
-  static constexpr std::size_t kLengthMultiplier = 4;
+  static constexpr std::size_t kLengthMultiplier =
+      kRecordHeaderLengthMultiplier;
 
   // The length of the message in 32-bit words.
   std::uint8_t length;
@@ -537,5 +539,6 @@ std::ostream& operator<<(std::ostream& stream,
                          const SymbolMappingMsg& symbol_mapping_msg);
 
 // The length in bytes of the largest record type.
-static constexpr std::size_t kMaxRecordLen = sizeof(InstrumentDefMsg);
+static constexpr std::size_t kMaxRecordLen =
+    sizeof(WithTsOut<InstrumentDefMsg>);
 }  // namespace databento

--- a/include/databento/with_ts_out.hpp
+++ b/include/databento/with_ts_out.hpp
@@ -11,7 +11,7 @@ template <typename R>
 struct WithTsOut {
   static bool HasRType(RType rtype) { return R::HasRType(rtype); }
 
-  constexpr WithTsOut(R r, UnixNanos ts) : rec{r}, ts_out{ts} {
+  WithTsOut(R r, UnixNanos ts) : rec{r}, ts_out{ts} {
     // Adjust length for `ts_out`
     this->rec.hd.length = sizeof(*this) / kRecordHeaderLengthMultiplier;
   }

--- a/include/databento/with_ts_out.hpp
+++ b/include/databento/with_ts_out.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "databento/datetime.hpp"  // UnixNanos
-#include "databento/enums.hpp"
+#include "databento/constants.hpp"  // kRecordHeaderLengthMultiplier
+#include "databento/datetime.hpp"   // UnixNanos
+#include "databento/enums.hpp"      // RType
 
 namespace databento {
 // Record wrapper to read records with their live gateway send
@@ -9,6 +10,11 @@ namespace databento {
 template <typename R>
 struct WithTsOut {
   static bool HasRType(RType rtype) { return R::HasRType(rtype); }
+
+  constexpr WithTsOut(R r, UnixNanos ts) : rec{r}, ts_out{ts} {
+    // Adjust length for `ts_out`
+    this->rec.hd.length = sizeof(*this) / kRecordHeaderLengthMultiplier;
+  }
 
   // The base record.
   R rec;

--- a/pkg/PKGBUILD
+++ b/pkg/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Databento <support@databento.com>
 _pkgname=databento-cpp
 pkgname=databento-cpp-git
-pkgver=0.15.0
+pkgver=0.16.0
 pkgrel=1
 pkgdesc="Official C++ client for Databento"
 arch=('any')

--- a/src/dbn_decoder.cpp
+++ b/src/dbn_decoder.cpp
@@ -57,7 +57,7 @@ DbnDecoder::DbnDecoder(detail::FileStream file_stream)
           new detail::FileStream{std::move(file_stream)}}) {}
 
 DbnDecoder::DbnDecoder(std::unique_ptr<IReadable> input)
-    : DbnDecoder(std::move(input), VersionUpgradePolicy::AsIs) {}
+    : DbnDecoder(std::move(input), VersionUpgradePolicy::Upgrade) {}
 
 DbnDecoder::DbnDecoder(std::unique_ptr<IReadable> input,
                        VersionUpgradePolicy upgrade_policy)

--- a/src/dbn_decoder.cpp
+++ b/src/dbn_decoder.cpp
@@ -13,6 +13,7 @@
 #include "databento/enums.hpp"
 #include "databento/exceptions.hpp"
 #include "databento/record.hpp"
+#include "databento/with_ts_out.hpp"
 
 using databento::DbnDecoder;
 
@@ -188,23 +189,47 @@ databento::Metadata DbnDecoder::DecodeMetadata() {
   read_buffer_.resize(version_and_size.second);
   input_->ReadExact(read_buffer_.data(), read_buffer_.size());
   buffer_idx_ = read_buffer_.size();
-  return DbnDecoder::DecodeMetadataFields(version_, read_buffer_);
+  auto metadata = DbnDecoder::DecodeMetadataFields(version_, read_buffer_);
+  ts_out_ = metadata.ts_out;
+  return metadata;
 }
 
+namespace {
+template <typename T, typename U>
+databento::Record UpgradeRecord(
+    bool ts_out,
+    std::array<std::uint8_t, databento::kMaxRecordLen>* compat_buffer,
+    databento::Record rec) {
+  if (ts_out) {
+    const auto orig = rec.Get<databento::WithTsOut<T>>();
+    const databento::WithTsOut<U> v2{orig.rec.ToV2(), orig.ts_out};
+    const auto v2_ptr = reinterpret_cast<const std::uint8_t*>(&v2);
+    std::copy(v2_ptr, v2_ptr + v2.rec.hd.Size(), compat_buffer->data());
+  } else {
+    const auto v2 = rec.Get<T>().ToV2();
+    const auto v2_ptr = reinterpret_cast<const std::uint8_t*>(&v2);
+    std::copy(v2_ptr, v2_ptr + v2.hd.Size(), compat_buffer->data());
+  }
+  return databento::Record{
+      reinterpret_cast<databento::RecordHeader*>(compat_buffer->data())};
+}
+}  // namespace
+
 databento::Record DbnDecoder::DecodeRecordCompat(
-    std::uint8_t version, VersionUpgradePolicy upgrade_policy,
+    std::uint8_t version, VersionUpgradePolicy upgrade_policy, bool ts_out,
     std::array<std::uint8_t, kMaxRecordLen>* compat_buffer, Record rec) {
   if (version == 1 && upgrade_policy == VersionUpgradePolicy::Upgrade) {
     if (rec.RType() == RType::InstrumentDef) {
-      auto v2 = rec.Get<InstrumentDefMsgV1>().ToV2();
-      auto v2_ptr = reinterpret_cast<std::uint8_t*>(&v2);
-      std::copy(v2_ptr, v2_ptr + v2.hd.Size(), compat_buffer->data());
-      return Record{reinterpret_cast<RecordHeader*>(compat_buffer->data())};
+      return UpgradeRecord<InstrumentDefMsgV1, InstrumentDefMsgV2>(
+          ts_out, compat_buffer, rec);
     } else if (rec.RType() == RType::SymbolMapping) {
-      auto v2 = rec.Get<SymbolMappingMsgV1>().ToV2();
-      auto v2_ptr = reinterpret_cast<std::uint8_t*>(&v2);
-      std::copy(v2_ptr, v2_ptr + v2.hd.Size(), compat_buffer->data());
-      return Record{reinterpret_cast<RecordHeader*>(compat_buffer->data())};
+      return UpgradeRecord<SymbolMappingMsgV1, SymbolMappingMsgV2>(
+          ts_out, compat_buffer, rec);
+    } else if (rec.RType() == RType::Error) {
+      return UpgradeRecord<ErrorMsgV1, ErrorMsgV2>(ts_out, compat_buffer, rec);
+    } else if (rec.RType() == RType::System) {
+      return UpgradeRecord<SystemMsgV1, SystemMsgV2>(ts_out, compat_buffer,
+                                                     rec);
     }
   }
   return rec;
@@ -228,7 +253,7 @@ const databento::Record* DbnDecoder::DecodeRecord() {
   current_record_ = Record{BufferRecordHeader()};
   buffer_idx_ += current_record_.Size();
   current_record_ = DbnDecoder::DecodeRecordCompat(
-      version_, upgrade_policy_, &compat_buffer_, current_record_);
+      version_, upgrade_policy_, ts_out_, &compat_buffer_, current_record_);
   return &current_record_;
 }
 

--- a/src/enums.cpp
+++ b/src/enums.cpp
@@ -462,6 +462,15 @@ const char* ToString(StatType stat_type) {
     case StatType::FixingPrice: {
       return "FixingPrice";
     }
+    case StatType::ClosePrice: {
+      return "ClosePrice";
+    }
+    case StatType::NetChange: {
+      return "NetChange";
+    }
+    case StatType::Vwap: {
+      return "Vwap";
+    }
     default: {
       return "Unknown";
     }

--- a/src/live_blocking.cpp
+++ b/src/live_blocking.cpp
@@ -143,8 +143,9 @@ const databento::Record* LiveBlocking::NextRecord(
   }
   current_record_ = Record{BufferRecordHeader()};
   buffer_idx_ += current_record_.Size();
-  current_record_ = DbnDecoder::DecodeRecordCompat(
-      version_, upgrade_policy_, &compat_buffer_, current_record_);
+  current_record_ =
+      DbnDecoder::DecodeRecordCompat(version_, upgrade_policy_, send_ts_out_,
+                                     &compat_buffer_, current_record_);
   return &current_record_;
 }
 

--- a/src/publishers.cpp
+++ b/src/publishers.cpp
@@ -134,6 +134,9 @@ const char* ToString(Venue venue) {
     case Venue::Sphr: {
       return "SPHR";
     }
+    case Venue::Ltse: {
+      return "LTSE";
+    }
     default: {
       return "Unknown";
     }
@@ -270,6 +273,9 @@ Venue FromString(const std::string& str) {
   if (str == "SPHR") {
     return Venue::Sphr;
   }
+  if (str == "LTSE") {
+    return Venue::Ltse;
+  }
   throw InvalidArgumentError{"FromString<Venue>", "str",
                              "unknown value '" + str + '\''};
 }
@@ -362,6 +368,9 @@ const char* ToString(Dataset dataset) {
     }
     case Dataset::NdexImpact: {
       return "NDEX.IMPACT";
+    }
+    case Dataset::DbeqMax: {
+      return "DBEQ.MAX";
     }
     default: {
       return "Unknown";
@@ -462,6 +471,9 @@ Dataset FromString(const std::string& str) {
   }
   if (str == "NDEX.IMPACT") {
     return Dataset::NdexImpact;
+  }
+  if (str == "DBEQ.MAX") {
+    return Dataset::DbeqMax;
   }
   throw InvalidArgumentError{"FromString<Dataset>", "str",
                              "unknown value '" + str + '\''};
@@ -651,6 +663,63 @@ Venue PublisherVenue(Publisher publisher) {
     }
     case Publisher::OpraPillarSphr: {
       return Venue::Sphr;
+    }
+    case Publisher::DbeqMaxXchi: {
+      return Venue::Xchi;
+    }
+    case Publisher::DbeqMaxXcis: {
+      return Venue::Xcis;
+    }
+    case Publisher::DbeqMaxIexg: {
+      return Venue::Iexg;
+    }
+    case Publisher::DbeqMaxEprl: {
+      return Venue::Eprl;
+    }
+    case Publisher::DbeqMaxXnas: {
+      return Venue::Xnas;
+    }
+    case Publisher::DbeqMaxXnys: {
+      return Venue::Xnys;
+    }
+    case Publisher::DbeqMaxFinn: {
+      return Venue::Finn;
+    }
+    case Publisher::DbeqMaxFiny: {
+      return Venue::Finy;
+    }
+    case Publisher::DbeqMaxFinc: {
+      return Venue::Finc;
+    }
+    case Publisher::DbeqMaxBats: {
+      return Venue::Bats;
+    }
+    case Publisher::DbeqMaxBaty: {
+      return Venue::Baty;
+    }
+    case Publisher::DbeqMaxEdga: {
+      return Venue::Edga;
+    }
+    case Publisher::DbeqMaxEdgx: {
+      return Venue::Edgx;
+    }
+    case Publisher::DbeqMaxXbos: {
+      return Venue::Xbos;
+    }
+    case Publisher::DbeqMaxXpsx: {
+      return Venue::Xpsx;
+    }
+    case Publisher::DbeqMaxMemx: {
+      return Venue::Memx;
+    }
+    case Publisher::DbeqMaxXase: {
+      return Venue::Xase;
+    }
+    case Publisher::DbeqMaxArcx: {
+      return Venue::Arcx;
+    }
+    case Publisher::DbeqMaxLtse: {
+      return Venue::Ltse;
     }
     default: {
       throw InvalidArgumentError{
@@ -845,6 +914,63 @@ Dataset PublisherDataset(Publisher publisher) {
     case Publisher::OpraPillarSphr: {
       return Dataset::OpraPillar;
     }
+    case Publisher::DbeqMaxXchi: {
+      return Dataset::DbeqMax;
+    }
+    case Publisher::DbeqMaxXcis: {
+      return Dataset::DbeqMax;
+    }
+    case Publisher::DbeqMaxIexg: {
+      return Dataset::DbeqMax;
+    }
+    case Publisher::DbeqMaxEprl: {
+      return Dataset::DbeqMax;
+    }
+    case Publisher::DbeqMaxXnas: {
+      return Dataset::DbeqMax;
+    }
+    case Publisher::DbeqMaxXnys: {
+      return Dataset::DbeqMax;
+    }
+    case Publisher::DbeqMaxFinn: {
+      return Dataset::DbeqMax;
+    }
+    case Publisher::DbeqMaxFiny: {
+      return Dataset::DbeqMax;
+    }
+    case Publisher::DbeqMaxFinc: {
+      return Dataset::DbeqMax;
+    }
+    case Publisher::DbeqMaxBats: {
+      return Dataset::DbeqMax;
+    }
+    case Publisher::DbeqMaxBaty: {
+      return Dataset::DbeqMax;
+    }
+    case Publisher::DbeqMaxEdga: {
+      return Dataset::DbeqMax;
+    }
+    case Publisher::DbeqMaxEdgx: {
+      return Dataset::DbeqMax;
+    }
+    case Publisher::DbeqMaxXbos: {
+      return Dataset::DbeqMax;
+    }
+    case Publisher::DbeqMaxXpsx: {
+      return Dataset::DbeqMax;
+    }
+    case Publisher::DbeqMaxMemx: {
+      return Dataset::DbeqMax;
+    }
+    case Publisher::DbeqMaxXase: {
+      return Dataset::DbeqMax;
+    }
+    case Publisher::DbeqMaxArcx: {
+      return Dataset::DbeqMax;
+    }
+    case Publisher::DbeqMaxLtse: {
+      return Dataset::DbeqMax;
+    }
     default: {
       throw InvalidArgumentError{
           "PublisherDataset", "publisher",
@@ -1038,6 +1164,63 @@ const char* ToString(Publisher publisher) {
     }
     case Publisher::OpraPillarSphr: {
       return "OPRA.PILLAR.SPHR";
+    }
+    case Publisher::DbeqMaxXchi: {
+      return "DBEQ.MAX.XCHI";
+    }
+    case Publisher::DbeqMaxXcis: {
+      return "DBEQ.MAX.XCIS";
+    }
+    case Publisher::DbeqMaxIexg: {
+      return "DBEQ.MAX.IEXG";
+    }
+    case Publisher::DbeqMaxEprl: {
+      return "DBEQ.MAX.EPRL";
+    }
+    case Publisher::DbeqMaxXnas: {
+      return "DBEQ.MAX.XNAS";
+    }
+    case Publisher::DbeqMaxXnys: {
+      return "DBEQ.MAX.XNYS";
+    }
+    case Publisher::DbeqMaxFinn: {
+      return "DBEQ.MAX.FINN";
+    }
+    case Publisher::DbeqMaxFiny: {
+      return "DBEQ.MAX.FINY";
+    }
+    case Publisher::DbeqMaxFinc: {
+      return "DBEQ.MAX.FINC";
+    }
+    case Publisher::DbeqMaxBats: {
+      return "DBEQ.MAX.BATS";
+    }
+    case Publisher::DbeqMaxBaty: {
+      return "DBEQ.MAX.BATY";
+    }
+    case Publisher::DbeqMaxEdga: {
+      return "DBEQ.MAX.EDGA";
+    }
+    case Publisher::DbeqMaxEdgx: {
+      return "DBEQ.MAX.EDGX";
+    }
+    case Publisher::DbeqMaxXbos: {
+      return "DBEQ.MAX.XBOS";
+    }
+    case Publisher::DbeqMaxXpsx: {
+      return "DBEQ.MAX.XPSX";
+    }
+    case Publisher::DbeqMaxMemx: {
+      return "DBEQ.MAX.MEMX";
+    }
+    case Publisher::DbeqMaxXase: {
+      return "DBEQ.MAX.XASE";
+    }
+    case Publisher::DbeqMaxArcx: {
+      return "DBEQ.MAX.ARCX";
+    }
+    case Publisher::DbeqMaxLtse: {
+      return "DBEQ.MAX.LTSE";
     }
     default: {
       return "Unknown";
@@ -1234,6 +1417,63 @@ Publisher FromString(const std::string& str) {
   }
   if (str == "OPRA.PILLAR.SPHR") {
     return Publisher::OpraPillarSphr;
+  }
+  if (str == "DBEQ.MAX.XCHI") {
+    return Publisher::DbeqMaxXchi;
+  }
+  if (str == "DBEQ.MAX.XCIS") {
+    return Publisher::DbeqMaxXcis;
+  }
+  if (str == "DBEQ.MAX.IEXG") {
+    return Publisher::DbeqMaxIexg;
+  }
+  if (str == "DBEQ.MAX.EPRL") {
+    return Publisher::DbeqMaxEprl;
+  }
+  if (str == "DBEQ.MAX.XNAS") {
+    return Publisher::DbeqMaxXnas;
+  }
+  if (str == "DBEQ.MAX.XNYS") {
+    return Publisher::DbeqMaxXnys;
+  }
+  if (str == "DBEQ.MAX.FINN") {
+    return Publisher::DbeqMaxFinn;
+  }
+  if (str == "DBEQ.MAX.FINY") {
+    return Publisher::DbeqMaxFiny;
+  }
+  if (str == "DBEQ.MAX.FINC") {
+    return Publisher::DbeqMaxFinc;
+  }
+  if (str == "DBEQ.MAX.BATS") {
+    return Publisher::DbeqMaxBats;
+  }
+  if (str == "DBEQ.MAX.BATY") {
+    return Publisher::DbeqMaxBaty;
+  }
+  if (str == "DBEQ.MAX.EDGA") {
+    return Publisher::DbeqMaxEdga;
+  }
+  if (str == "DBEQ.MAX.EDGX") {
+    return Publisher::DbeqMaxEdgx;
+  }
+  if (str == "DBEQ.MAX.XBOS") {
+    return Publisher::DbeqMaxXbos;
+  }
+  if (str == "DBEQ.MAX.XPSX") {
+    return Publisher::DbeqMaxXpsx;
+  }
+  if (str == "DBEQ.MAX.MEMX") {
+    return Publisher::DbeqMaxMemx;
+  }
+  if (str == "DBEQ.MAX.XASE") {
+    return Publisher::DbeqMaxXase;
+  }
+  if (str == "DBEQ.MAX.ARCX") {
+    return Publisher::DbeqMaxArcx;
+  }
+  if (str == "DBEQ.MAX.LTSE") {
+    return Publisher::DbeqMaxLtse;
   }
   throw InvalidArgumentError{"FromString<Publisher>", "str",
                              "unknown value '" + str + '\''};

--- a/test/src/live_blocking_tests.cpp
+++ b/test/src/live_blocking_tests.cpp
@@ -267,7 +267,7 @@ TEST_F(LiveBlockingTests, TestNextRecordWithTsOut) {
   constexpr auto kRecCount = 5;
   constexpr auto kTsOut = true;
   constexpr WithTsOut<TradeMsg> kRec{
-      {DummyHeader<WithTsOut<TradeMsg>>(RType::Mbp0),
+      {DummyHeader<TradeMsg>(RType::Mbp0),
        1,
        2,
        Action::Add,


### PR DESCRIPTION

### Enhancements
- Added new publisher values for consolidated DBEQ.MAX
- Added constructor to `WithTsOut` that updates `length` to the correct value to account
  for the extra 8 bytes
- Upgrade default cpp-httplib version to 0.14.3 (last to still support OpenSSL 1.1)
- Upgrade default nlohmann_json version to 3.11.3

### Breaking changes
- Changed default `upgrade_policy` to `Upgrade` so by default the primary record types
  can always be used
- Renamed `dummy` field in `ImbalanceMsg` and `StatMsg` to `reserved`

### Bug fixes
- Fixed handling of `ts_out` when decoding DBNv1 and upgrading to version 2
- Fixed missing logic to upgrade `ErrorMsgV1` and `SystemMsgV1` when decoding DBN with
  `VersionUpgradePolicy::Upgrade`
- Added missing `StatType::Vwap` variant used in the ICE datasets
- Added missing `ToString` and `operator<<` handling for `StatType::ClosePrice` and
  `StatType::NetChange`
- Fixed potential for invalid reads when decoding C strings in `DbnDecoder`