### PR TITLE
reorder initializer list for DbnDecoder

### DIFF
--- a/src/dbn_decoder.cpp
+++ b/src/dbn_decoder.cpp
@@ -74,7 +74,7 @@ DbnDecoder::DbnDecoder(std::unique_ptr<IReadable> input)
 
 DbnDecoder::DbnDecoder(std::unique_ptr<IReadable> input,
                        VersionUpgradePolicy upgrade_policy)
-    : input_{std::move(input)}, upgrade_policy_{upgrade_policy} {
+    : upgrade_policy_{upgrade_policy}, input_{std::move(input)} {
   read_buffer_.reserve(kBufferCapacity);
   if (DetectCompression()) {
     input_ = std::unique_ptr<detail::ZstdStream>(


### PR DESCRIPTION
…rder they would be initialized

# Pull Request

reorder of initializer list to soothe the reorder warning, and also make it clearer for the reader.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested?

this has not been tested other than checking that it still builds.
