### PR TITLE
deal with conan zstd dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,18 @@ endif()
 find_package(Zstd REQUIRED)
 find_package(Threads REQUIRED)
 
+# Check if the Conan-provided target exists
+if(TARGET zstd::libzstd_static)
+  # If the Conan target exists, use it
+  set(ZSTD_TARGET zstd::libzstd_static)
+elseif(TARGET zstd::zstd)
+  # If the system-installed target exists, use it
+  set(ZSTD_TARGET zstd::zstd)
+else()
+  # Error out if neither target is found
+  message(FATAL_ERROR "Zstd target not found.")
+endif()
+
 #
 # Platform-specific dependencies
 #
@@ -211,7 +223,7 @@ target_link_libraries(
     OpenSSL::Crypto
     OpenSSL::SSL
     Threads::Threads
-    zstd::zstd
+    ${ZSTD_TARGET}
 )
 
 target_compile_definitions(


### PR DESCRIPTION
# Pull request

this changes the cmake target that is used to build databento-cpp incase zstd is installed with a different cmake target name (for example via Conan). This is because Conan installed zstd only defines `zstd::libzstd_static` while databento looked for only `ztsd::zstd`. https://conan.io/center/recipes/zstd.
with this change, it will first check for the conan installed target (to allow users to more freely choose zstd version), and use the system wide installed zstd target as fallback.


## Type of change
allow databento-cpp to be built with conan installed zstd.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.

c++ project using conan and cmake. databento-cpp is included as a git submodule and a cmake subdirectory.

- [x] built project including databento-cpp as submodule with system installed zstd
- [x] built project including databento-cpp as submodule with conan installed zstd

## Checklist

- [x] My code builds locally with no new warnings (`scripts/build.sh`). 
- [x] New and existing unit tests pass locally with my changes (`scripts/test.sh`)
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Declaration

I confirm this contribution is made under an Apache 2.0 license and that I have the authority
necessary to make this contribution on behalf of its copyright owner.
