### PR TITLE
VER: Release 0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.18.1 - TBD
+
+### Bug fixes
+- Added missing symbol chunking for live `Subscribe` overloads with `const std::string&`
+  `start` parameter
+
 ## 0.18.0 - 2024-05-14
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
 
-## 0.18.1 - TBD
+## 0.18.1 - 2024-05-22
 
 ### Enhancements
 - Added live `Subscribe` function overload with `use_snapshot` parameter
+- Added `GetIf` method to `Record` that allows `if` chaining for handling multiple
+  record types
+- Added record type checking to `Record::Get` method to catch programming errors
+  and prevent reading invalid data
 
 ### Bug fixes
 - Added missing symbol chunking for live `Subscribe` overloads with `const std::string&`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.18.1 - TBD
 
+### Enhancements
+- Added live `Subscribe` function overload with `use_snapshot` parameter
+
 ### Bug fixes
 - Added missing symbol chunking for live `Subscribe` overloads with `const std::string&`
   `start` parameter

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.14)
 # Project details
 #
 
-project("databento" VERSION 0.18.0 LANGUAGES CXX)
+project("databento" VERSION 0.18.1 LANGUAGES CXX)
 string(TOUPPER ${PROJECT_NAME} PROJECT_NAME_UPPERCASE)
 
 #

--- a/README.md
+++ b/README.md
@@ -108,10 +108,9 @@ int main() {
 
   auto handler = [&symbol_mappings](const Record& rec) {
     symbol_mappings.OnRecord(rec);
-    if (rec.Holds<TradeMsg>()) {
-      auto trade = rec.Get<TradeMsg>();
+    if (const auto* trade = rec.GetIf<TradeMsg>()) {
       std::cout << "Received trade for "
-                << symbol_mappings[trade.hd.instrument_id] << ':' << trade
+                << symbol_mappings[trade->hd.instrument_id] << ':' << *trade
                 << '\n';
     }
     return KeepGoing::Continue;

--- a/example/live/readme.cpp
+++ b/example/live/readme.cpp
@@ -18,10 +18,9 @@ int main() {
 
   auto handler = [&symbol_mappings](const Record& rec) {
     symbol_mappings.OnRecord(rec);
-    if (rec.Holds<TradeMsg>()) {
-      auto trade = rec.Get<TradeMsg>();
+    if (const auto* trade = rec.GetIf<TradeMsg>()) {
       std::cout << "Received trade for "
-                << symbol_mappings[trade.hd.instrument_id] << ':' << trade
+                << symbol_mappings[trade->hd.instrument_id] << ':' << *trade
                 << '\n';
     }
     return KeepGoing::Continue;

--- a/include/databento/live_blocking.hpp
+++ b/include/databento/live_blocking.hpp
@@ -50,6 +50,8 @@ class LiveBlocking {
                  SType stype_in, UnixNanos start);
   void Subscribe(const std::vector<std::string>& symbols, Schema schema,
                  SType stype_in, const std::string& start);
+  void Subscribe(const std::vector<std::string>& symbols, Schema schema,
+                 SType stype_in, bool use_snapshot);
   // Notifies the gateway to start sending messages for all subscriptions.
   //
   // This method should only be called once per instance.
@@ -79,7 +81,7 @@ class LiveBlocking {
   std::string EncodeAuthReq(const std::string& auth);
   std::uint64_t DecodeAuthResp();
   void Subscribe(const std::string& sub_msg,
-                 const std::vector<std::string>& symbols);
+                 const std::vector<std::string>& symbols, bool use_snapshot);
   detail::TcpClient::Result FillBuffer(std::chrono::milliseconds timeout);
   RecordHeader* BufferRecordHeader();
 

--- a/include/databento/live_blocking.hpp
+++ b/include/databento/live_blocking.hpp
@@ -78,6 +78,8 @@ class LiveBlocking {
   std::string GenerateCramReply(const std::string& challenge_key);
   std::string EncodeAuthReq(const std::string& auth);
   std::uint64_t DecodeAuthResp();
+  void Subscribe(const std::string& sub_msg,
+                 const std::vector<std::string>& symbols);
   detail::TcpClient::Result FillBuffer(std::chrono::milliseconds timeout);
   RecordHeader* BufferRecordHeader();
 

--- a/include/databento/live_threaded.hpp
+++ b/include/databento/live_threaded.hpp
@@ -65,6 +65,8 @@ class LiveThreaded {
                  SType stype_in, UnixNanos start);
   void Subscribe(const std::vector<std::string>& symbols, Schema schema,
                  SType stype_in, const std::string& start);
+  void Subscribe(const std::vector<std::string>& symbols, Schema schema,
+                 SType stype_in, bool use_snapshot);
   // Notifies the gateway to start sending messages for all subscriptions.
   // `metadata_callback` will be called exactly once, before any calls to
   // `record_callback`. `record_callback` will be called for records from all

--- a/pkg/PKGBUILD
+++ b/pkg/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Databento <support@databento.com>
 _pkgname=databento-cpp
 pkgname=databento-cpp-git
-pkgver=0.18.0
+pkgver=0.18.1
 pkgrel=1
 pkgdesc="Official C++ client for Databento"
 arch=('any')

--- a/src/live_blocking.cpp
+++ b/src/live_blocking.cpp
@@ -59,8 +59,32 @@ void LiveBlocking::Subscribe(const std::vector<std::string>& symbols,
 
 void LiveBlocking::Subscribe(const std::vector<std::string>& symbols,
                              Schema schema, SType stype_in, UnixNanos start) {
+  std::ostringstream sub_msg;
+  sub_msg << "schema=" << ToString(schema)
+          << "|stype_in=" << ToString(stype_in);
+  if (start.time_since_epoch().count()) {
+    sub_msg << "|start=" << start.time_since_epoch().count();
+  }
+  Subscribe(sub_msg.str(), symbols);
+}
+
+void LiveBlocking::Subscribe(const std::vector<std::string>& symbols,
+                             Schema schema, SType stype_in,
+                             const std::string& start) {
+  std::ostringstream sub_msg;
+  sub_msg << "schema=" << ToString(schema)
+          << "|stype_in=" << ToString(stype_in);
+  if (!start.empty()) {
+    sub_msg << "|start=" << start;
+  }
+  Subscribe(sub_msg.str(), symbols);
+}
+
+void LiveBlocking::Subscribe(const std::string& sub_msg,
+                             const std::vector<std::string>& symbols) {
   static constexpr auto kMethodName = "Live::Subscribe";
   constexpr std::ptrdiff_t kSymbolMaxChunkSize = 128;
+
   if (symbols.empty()) {
     throw InvalidArgumentError{kMethodName, "symbols",
                                "must contain at least one symbol"};
@@ -70,34 +94,15 @@ void LiveBlocking::Subscribe(const std::vector<std::string>& symbols,
     const auto chunk_size =
         std::min(kSymbolMaxChunkSize, std::distance(symbols_it, symbols.end()));
 
-    std::ostringstream sub_msg;
-    sub_msg << "schema=" << ToString(schema)
-            << "|stype_in=" << ToString(stype_in) << "|symbols="
-            << JoinSymbolStrings(kMethodName, symbols_it,
-                                 symbols_it + chunk_size);
-    if (start.time_since_epoch().count()) {
-      sub_msg << "|start=" << start.time_since_epoch().count();
-    }
-    sub_msg << '\n';
-    client_.WriteAll(sub_msg.str());
+    std::ostringstream chunked_sub_msg;
+    chunked_sub_msg << sub_msg << "|symbols="
+                    << JoinSymbolStrings(kMethodName, symbols_it,
+                                         symbols_it + chunk_size)
+                    << '\n';
+    client_.WriteAll(chunked_sub_msg.str());
 
     symbols_it += chunk_size;
   }
-}
-
-void LiveBlocking::Subscribe(const std::vector<std::string>& symbols,
-                             Schema schema, SType stype_in,
-                             const std::string& start) {
-  std::ostringstream sub_msg;
-  sub_msg << "schema=" << ToString(schema) << "|stype_in=" << ToString(stype_in)
-          << "|symbols="
-          << JoinSymbolStrings("LiveBlocking::Subscribe", symbols);
-  if (!start.empty()) {
-    sub_msg << "|start=" << start;
-  }
-  sub_msg << '\n';
-
-  client_.WriteAll(sub_msg.str());
 }
 
 databento::Metadata LiveBlocking::Start() {

--- a/src/live_blocking.cpp
+++ b/src/live_blocking.cpp
@@ -65,7 +65,7 @@ void LiveBlocking::Subscribe(const std::vector<std::string>& symbols,
   if (start.time_since_epoch().count()) {
     sub_msg << "|start=" << start.time_since_epoch().count();
   }
-  Subscribe(sub_msg.str(), symbols);
+  Subscribe(sub_msg.str(), symbols, false);
 }
 
 void LiveBlocking::Subscribe(const std::vector<std::string>& symbols,
@@ -77,11 +77,21 @@ void LiveBlocking::Subscribe(const std::vector<std::string>& symbols,
   if (!start.empty()) {
     sub_msg << "|start=" << start;
   }
-  Subscribe(sub_msg.str(), symbols);
+  Subscribe(sub_msg.str(), symbols, false);
+}
+
+void LiveBlocking::Subscribe(const std::vector<std::string>& symbols,
+                             Schema schema, SType stype_in, bool use_snapshot) {
+  std::ostringstream sub_msg;
+  sub_msg << "schema=" << ToString(schema)
+          << "|stype_in=" << ToString(stype_in);
+
+  Subscribe(sub_msg.str(), symbols, use_snapshot);
 }
 
 void LiveBlocking::Subscribe(const std::string& sub_msg,
-                             const std::vector<std::string>& symbols) {
+                             const std::vector<std::string>& symbols,
+                             bool use_snapshot) {
   static constexpr auto kMethodName = "Live::Subscribe";
   constexpr std::ptrdiff_t kSymbolMaxChunkSize = 128;
 
@@ -98,7 +108,7 @@ void LiveBlocking::Subscribe(const std::string& sub_msg,
     chunked_sub_msg << sub_msg << "|symbols="
                     << JoinSymbolStrings(kMethodName, symbols_it,
                                          symbols_it + chunk_size)
-                    << '\n';
+                    << "|snapshot=" << use_snapshot << '\n';
     client_.WriteAll(chunked_sub_msg.str());
 
     symbols_it += chunk_size;

--- a/src/live_threaded.cpp
+++ b/src/live_threaded.cpp
@@ -102,6 +102,11 @@ void LiveThreaded::Subscribe(const std::vector<std::string>& symbols,
   impl_->blocking.Subscribe(symbols, schema, stype_in, start);
 }
 
+void LiveThreaded::Subscribe(const std::vector<std::string>& symbols,
+                             Schema schema, SType stype_in, bool use_snapshot) {
+  impl_->blocking.Subscribe(symbols, schema, stype_in, use_snapshot);
+}
+
 void LiveThreaded::Start(RecordCallback callback) {
   Start({}, std::move(callback), {});
 }

--- a/src/record.cpp
+++ b/src/record.cpp
@@ -189,7 +189,15 @@ bool databento::operator==(const ImbalanceMsg& lhs, const ImbalanceMsg& rhs) {
 }
 
 namespace databento {
-
+std::string ToString(const Record& record) { return MakeString(record); }
+std::ostream& operator<<(std::ostream& stream, const Record& record) {
+  return StreamOpBuilder{stream}
+      .SetSpacer(" ")
+      .SetTypeName("Record")
+      .Build()
+      .AddField("ptr", record.Header())
+      .Finish();
+}
 std::string ToString(const RecordHeader& header) { return MakeString(header); }
 std::ostream& operator<<(std::ostream& stream, const RecordHeader& header) {
   return StreamOpBuilder{stream}

--- a/test/include/mock/mock_lsg_server.hpp
+++ b/test/include/mock/mock_lsg_server.hpp
@@ -34,9 +34,10 @@ class MockLsgServer {
   void Accept();
   void Authenticate();
   void Subscribe(const std::vector<std::string>& symbols, Schema schema,
-                 SType stype);
+                 SType stype, bool use_snapshot = false);
   void Subscribe(const std::vector<std::string>& symbols, Schema schema,
-                 SType stype, const std::string& start);
+                 SType stype, const std::string& start,
+                 bool use_snapshot = false);
   void Start();
   std::size_t Send(const std::string& msg);
   ::ssize_t UncheckedSend(const std::string& msg);

--- a/test/include/mock/mock_lsg_server.hpp
+++ b/test/include/mock/mock_lsg_server.hpp
@@ -35,6 +35,8 @@ class MockLsgServer {
   void Authenticate();
   void Subscribe(const std::vector<std::string>& symbols, Schema schema,
                  SType stype);
+  void Subscribe(const std::vector<std::string>& symbols, Schema schema,
+                 SType stype, const std::string& start);
   void Start();
   std::size_t Send(const std::string& msg);
   ::ssize_t UncheckedSend(const std::string& msg);

--- a/test/src/live_blocking_tests.cpp
+++ b/test/src/live_blocking_tests.cpp
@@ -169,11 +169,12 @@ TEST_F(LiveBlockingTests, TestSubscribeSnapshot) {
   const std::size_t kSymbolCount = 1000;
   const auto kSchema = Schema::Ohlcv1M;
   const auto kSType = SType::RawSymbol;
-  const auto use_snapshot = true;
+  const auto kUseSnapshot = true;
 
   const mock::MockLsgServer mock_server{
       kDataset, kTsOut,
-      [kSymbol, kSymbolCount, kSchema, kSType](mock::MockLsgServer& self) {
+      [kSymbol, kSymbolCount, kSchema, kSType,
+       kUseSnapshot](mock::MockLsgServer& self) {
         self.Accept();
         self.Authenticate();
         std::size_t i{};
@@ -181,7 +182,7 @@ TEST_F(LiveBlockingTests, TestSubscribeSnapshot) {
           const auto chunk_size =
               std::min(static_cast<std::size_t>(128), kSymbolCount - i);
           const std::vector<std::string> symbols_chunk(chunk_size, kSymbol);
-          self.Subscribe(symbols_chunk, kSchema, kSType, use_snapshot);
+          self.Subscribe(symbols_chunk, kSchema, kSType, kUseSnapshot);
           i += chunk_size;
         }
       }};
@@ -194,7 +195,7 @@ TEST_F(LiveBlockingTests, TestSubscribeSnapshot) {
                       kTsOut,
                       VersionUpgradePolicy{}};
   const std::vector<std::string> kSymbols(kSymbolCount, kSymbol);
-  target.Subscribe(kSymbols, kSchema, kSType, use_snapshot);
+  target.Subscribe(kSymbols, kSchema, kSType, kUseSnapshot);
 }
 
 TEST_F(LiveBlockingTests, TestInvalidSubscription) {

--- a/test/src/live_blocking_tests.cpp
+++ b/test/src/live_blocking_tests.cpp
@@ -92,7 +92,7 @@ TEST_F(LiveBlockingTests, TestSubscribe) {
   target.Subscribe(kSymbols, kSchema, kSType);
 }
 
-TEST_F(LiveBlockingTests, TestSubscriptionChunking) {
+TEST_F(LiveBlockingTests, TestSubscriptionChunkingUnixNanos) {
   constexpr auto kTsOut = false;
   constexpr auto kDataset = dataset::kXnasItch;
   const auto kSymbol = "TEST";
@@ -124,6 +124,42 @@ TEST_F(LiveBlockingTests, TestSubscriptionChunking) {
                       VersionUpgradePolicy{}};
   const std::vector<std::string> kSymbols(kSymbolCount, kSymbol);
   target.Subscribe(kSymbols, kSchema, kSType);
+}
+
+TEST_F(LiveBlockingTests, TestSubscriptionChunkingStringStart) {
+  constexpr auto kTsOut = false;
+  constexpr auto kDataset = dataset::kXnasItch;
+  const auto kSymbol = "TEST";
+  const std::size_t kSymbolCount = 1000;
+  const auto kSchema = Schema::Ohlcv1M;
+  const auto kSType = SType::RawSymbol;
+  const auto kStart = "2020-01-01T00:00:00";
+
+  const mock::MockLsgServer mock_server{
+      kDataset, kTsOut,
+      [kSymbol, kSymbolCount, kSchema, kSType,
+       kStart](mock::MockLsgServer& self) {
+        self.Accept();
+        self.Authenticate();
+        std::size_t i{};
+        while (i < 1000) {
+          const auto chunk_size =
+              std::min(static_cast<std::size_t>(128), kSymbolCount - i);
+          const std::vector<std::string> symbols_chunk(chunk_size, kSymbol);
+          self.Subscribe(symbols_chunk, kSchema, kSType, kStart);
+          i += chunk_size;
+        }
+      }};
+
+  LiveBlocking target{logger_.get(),
+                      kKey,
+                      kDataset,
+                      kLocalhost,
+                      mock_server.Port(),
+                      kTsOut,
+                      VersionUpgradePolicy{}};
+  const std::vector<std::string> kSymbols(kSymbolCount, kSymbol);
+  target.Subscribe(kSymbols, kSchema, kSType, kStart);
 }
 
 TEST_F(LiveBlockingTests, TestNextRecord) {

--- a/test/src/live_threaded_tests.cpp
+++ b/test/src/live_threaded_tests.cpp
@@ -178,6 +178,7 @@ TEST_F(LiveThreadedTests, TestExceptionCallbackAndReconnect) {
                           {},
                           2};
 
+  const auto use_snapshot = true;
   bool should_close{};
   std::mutex should_close_mutex;
   std::condition_variable should_close_cv;
@@ -187,7 +188,7 @@ TEST_F(LiveThreadedTests, TestExceptionCallbackAndReconnect) {
        kSType](mock::MockLsgServer& self) {
         self.Accept();
         self.Authenticate();
-        self.Subscribe(kAllSymbols, kSchema, kSType);
+        self.Subscribe(kAllSymbols, kSchema, kSType, use_snapshot);
         self.Start();
         {
           std::unique_lock<std::mutex> shutdown_lock{should_close_mutex};
@@ -235,7 +236,8 @@ TEST_F(LiveThreadedTests, TestExceptionCallbackAndReconnect) {
       return LiveThreaded::ExceptionAction::Stop;
     }
   };
-  target.Subscribe(kAllSymbols, kSchema, kSType);
+
+  target.Subscribe(kAllSymbols, kSchema, kSType, use_snapshot);
   target.Start(metadata_cb, record_cb, exception_cb);
   target.BlockForStop();
   EXPECT_EQ(metadata_calls, 2);

--- a/test/src/live_threaded_tests.cpp
+++ b/test/src/live_threaded_tests.cpp
@@ -178,17 +178,17 @@ TEST_F(LiveThreadedTests, TestExceptionCallbackAndReconnect) {
                           {},
                           2};
 
-  const auto use_snapshot = true;
+  const auto kUseSnapshot = true;
   bool should_close{};
   std::mutex should_close_mutex;
   std::condition_variable should_close_cv;
   const mock::MockLsgServer mock_server{
       dataset::kXnasItch, kTsOut,
       [&should_close, &should_close_mutex, &should_close_cv, kRec, kSchema,
-       kSType](mock::MockLsgServer& self) {
+       kSType, kUseSnapshot](mock::MockLsgServer& self) {
         self.Accept();
         self.Authenticate();
-        self.Subscribe(kAllSymbols, kSchema, kSType, use_snapshot);
+        self.Subscribe(kAllSymbols, kSchema, kSType, kUseSnapshot);
         self.Start();
         {
           std::unique_lock<std::mutex> shutdown_lock{should_close_mutex};
@@ -237,7 +237,7 @@ TEST_F(LiveThreadedTests, TestExceptionCallbackAndReconnect) {
     }
   };
 
-  target.Subscribe(kAllSymbols, kSchema, kSType, use_snapshot);
+  target.Subscribe(kAllSymbols, kSchema, kSType, kUseSnapshot);
   target.Start(metadata_cb, record_cb, exception_cb);
   target.BlockForStop();
   EXPECT_EQ(metadata_calls, 2);

--- a/test/src/mock_lsg_server.cpp
+++ b/test/src/mock_lsg_server.cpp
@@ -91,13 +91,13 @@ void MockLsgServer::Authenticate() {
 }
 
 void MockLsgServer::Subscribe(const std::vector<std::string>& symbols,
-                              Schema schema, SType stype) {
-  Subscribe(symbols, schema, stype, {});
+                              Schema schema, SType stype, bool use_snapshot) {
+  Subscribe(symbols, schema, stype, {}, use_snapshot);
 }
 
 void MockLsgServer::Subscribe(const std::vector<std::string>& symbols,
                               Schema schema, SType stype,
-                              const std::string& start) {
+                              const std::string& start, bool use_snapshot) {
   const auto received = Receive();
   EXPECT_NE(
       received.find("symbols=" +
@@ -112,6 +112,10 @@ void MockLsgServer::Subscribe(const std::vector<std::string>& symbols,
   } else {
     EXPECT_NE(received.find(std::string{"start="} + start), std::string::npos);
   }
+
+  EXPECT_NE(
+      received.find(std::string{"snapshot="} + std::to_string(use_snapshot)),
+      std::string::npos);
 }
 
 void MockLsgServer::Start() {

--- a/test/src/mock_lsg_server.cpp
+++ b/test/src/mock_lsg_server.cpp
@@ -92,6 +92,12 @@ void MockLsgServer::Authenticate() {
 
 void MockLsgServer::Subscribe(const std::vector<std::string>& symbols,
                               Schema schema, SType stype) {
+  Subscribe(symbols, schema, stype, {});
+}
+
+void MockLsgServer::Subscribe(const std::vector<std::string>& symbols,
+                              Schema schema, SType stype,
+                              const std::string& start) {
   const auto received = Receive();
   EXPECT_NE(
       received.find("symbols=" +
@@ -101,6 +107,11 @@ void MockLsgServer::Subscribe(const std::vector<std::string>& symbols,
             std::string::npos);
   EXPECT_NE(received.find(std::string{"stype_in="} + ToString(stype)),
             std::string::npos);
+  if (start.empty()) {
+    EXPECT_EQ(received.find(std::string{"start="}), std::string::npos);
+  } else {
+    EXPECT_NE(received.find(std::string{"start="} + start), std::string::npos);
+  }
 }
 
 void MockLsgServer::Start() {

--- a/test/src/record_tests.cpp
+++ b/test/src/record_tests.cpp
@@ -11,6 +11,28 @@
 
 namespace databento {
 namespace test {
+TEST(RecordTests, TestRecordToString) {
+  TradeMsg target{
+      RecordHeader{sizeof(TradeMsg) / RecordHeader::kLengthMultiplier,
+                   RType::Mbp0,
+                   static_cast<std::uint16_t>(Publisher::OpraPillarEdgo),
+                   1,
+                   {}},
+      55000000000,
+      500,
+      Action::Add,
+      Side::Bid,
+      {},
+      0,
+      {},
+      {},
+      126239};
+  const Record rec{&target.hd};
+  EXPECT_EQ(
+      ToString(rec),
+      "Record { ptr = RecordHeader { length = 12, rtype = Mbp0, publisher_id = "
+      "24, instrument_id = 1, ts_event = 1970-01-01T00:00:00.000000000Z } }");
+}
 TEST(RecordTests, TestPublisher) {
   const TradeMsg target{
       RecordHeader{sizeof(TradeMsg) / RecordHeader::kLengthMultiplier,


### PR DESCRIPTION
##### Enhancements
- Added live `Subscribe` function overload with `use_snapshot` parameter
- Added `GetIf` method to `Record` that allows `if` chaining for handling multiple
  record types
- Added record type checking to `Record::Get` method to catch programming errors
  and prevent reading invalid data
- Added `ToString` for `Record`

##### Bug fixes
- Added missing symbol chunking for live `Subscribe` overloads with `const std::string&`
  `start` parameter