### PR TITLE
VER: Release 0.19.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,13 +24,13 @@ jobs:
           sudo apt-get install libpcre3 libpcre3-dev libzstd-dev ninja-build
       - name: Install cppcheck
         run: |
-          git clone https://github.com/danmar/cppcheck.git
+          git clone https://github.com/danmar/cppcheck.git --branch 2.14.1
           cd cppcheck
           cmake -S. -B build \
             -DCMAKE_BUILD_TYPE=Release \
-            -DUSE_MATCHCOMPILER=On \
+            -DUSE_MATCHCOMPILER=ON \
             -DHAVE_RULES=ON
-          cmake --build build --config Release
+          cmake --build build --config Release --parallel
           sudo cmake --install build --prefix /usr
       - name: Install gtest
         uses: MarkusJx/googletest-installer@v1.1
@@ -94,6 +94,6 @@ jobs:
             -DVCPKG_BUILD_TYPE=debug `
             -DDATABENTO_USE_EXTERNAL_GTEST=0
       - name: CMake build
-        run: cmake --build build --parallel 10
+        run: cmake --build build --parallel
       - name: Unit tests
         run: cd build && ctest --verbose --exclude-regex cmake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.19.0 - TBD
+## 0.19.0 - 2024-06-04
 
 ### Enhancements
 - Added configurable `heartbeat_interval` parameter for live clients that determines the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Enhancements
 - Added new `UncrossingPrice` `StatType` variant
+- Added new publisher values for `XNAS.BASIC`
+
+### Bug fixes
+- Fix descriptions for `FINN` and `FINY` publishers.
 
 ## 0.18.1 - 2024-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,16 @@
 ## 0.19.0 - TBD
 
 ### Enhancements
+- Added configurable `heartbeat_interval` parameter for live clients that determines the
+  timeout before heartbeat `SystemMsg` records will be sent. It can be configured via
+  the `SetHeartbeatInterval` method of the `LiveBuilder`
+- Added `SetAddress` method to `LiveBuilder` for configuring a custom gateway address
+  without using the constructor directly
 - Added new `UncrossingPrice` `StatType` variant
 - Added new publisher values for `XNAS.BASIC`
 
 ### Breaking changes
+- Added `heartbeat_interval` parameter to the `Live` constructors
 - Removed `start_date` and `end_date` fields from `DatasetRange` struct
   in favor of `start` and `end`
 - Removed live `Subscribe` method overloads with `use_snapshot`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 # Changelog
 
-## 0.19.0 - TBD
+## 0.18.2 - TBD
 
 ### Enhancements
 - Added new `UncrossingPrice` `StatType` variant
 - Added new publisher values for `XNAS.BASIC`
 
 ### Bug fixes
-- Fix descriptions for `FINN` and `FINY` publishers.
+- Fixed overloading of live `Subscribe` methods
+- Fixed live subscribing with default-constructed `UnixNanos`
+- Fixed descriptions for `FINN` and `FINY` publishers.
 
 ## 0.18.1 - 2024-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.19.0 - TBD
+
+### Enhancements
+- Added new `UncrossingPrice` `StatType` variant
+
 ## 0.18.1 - 2024-05-22
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added new `UncrossingPrice` `StatType` variant
 - Added new publisher values for `XNAS.BASIC`
 - Added `SetDataset(Dataset)` overload to `LiveBuilder`
+- Added new off-market publisher values for `IFEU.IMPACT` and `NDEX.IMPACT`
 
 ### Breaking changes
 - Added `heartbeat_interval` parameter to the `Live` constructors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   without using the constructor directly
 - Added new `UncrossingPrice` `StatType` variant
 - Added new publisher values for `XNAS.BASIC`
+- Added `SetDataset(Dataset)` overload to `LiveBuilder`
 
 ### Breaking changes
 - Added `heartbeat_interval` parameter to the `Live` constructors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
-## 0.18.2 - TBD
+## 0.19.0 - TBD
 
 ### Enhancements
 - Added new `UncrossingPrice` `StatType` variant
 - Added new publisher values for `XNAS.BASIC`
+
+### Breaking changes
+- Removed `start_date` and `end_date` fields from `DatasetRange` struct
+  in favor of `start` and `end`
+- Removed live `Subscribe` method overloads with `use_snapshot`
+  parameter in favor of separate `SubscribeWithSnapshot` method
 
 ### Bug fixes
 - Fixed overloading of live `Subscribe` methods

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.14)
 # Project details
 #
 
-project("databento" VERSION 0.18.1 LANGUAGES CXX)
+project("databento" VERSION 0.19.0 LANGUAGES CXX)
 string(TOUPPER ${PROJECT_NAME} PROJECT_NAME_UPPERCASE)
 
 #

--- a/include/databento/enums.hpp
+++ b/include/databento/enums.hpp
@@ -232,6 +232,7 @@ namespace stat_type {
 // The type of statistic contained in a StatMsg.
 enum StatType : std::uint16_t {
   // The price of the first trade of an instrument. `price` will be set.
+  // `quantity` will be set when provided by the venue.
   OpeningPrice = 1,
   // The probable price of the first trade of an instrument published during
   // pre-open. Both `price` and `quantity` will be set.
@@ -265,6 +266,7 @@ enum StatType : std::uint16_t {
   // be set.
   FixingPrice = 10,
   // The last trade price during a trading session. `price` will be set.
+  // `quantity` will be set when provided by the venue.
   ClosePrice = 11,
   // The change in price from the close price of the previous trading session to
   // the most recent trading session. `price` will be set.
@@ -279,6 +281,12 @@ enum StatType : std::uint16_t {
   // The option delta associated with the settlement price. `price` will be set
   // with the standard precision.
   Delta = 15,
+  // The auction uncrossing price. This is used for auctions that are neither
+  // the
+  // official opening auction nor the official closing auction. `price` will be
+  // set. `quantity` will be set when provided by the venue.
+  UncrossingPrice = 16,
+
 };
 }  // namespace stat_type
 using stat_type::StatType;

--- a/include/databento/live.hpp
+++ b/include/databento/live.hpp
@@ -6,6 +6,7 @@
 #include "databento/enums.hpp"  // VersionUpgradePolicy
 #include "databento/live_blocking.hpp"
 #include "databento/live_threaded.hpp"
+#include "databento/publishers.hpp"
 
 namespace databento {
 class ILogReceiver;
@@ -23,6 +24,7 @@ class LiveBuilder {
   LiveBuilder& SetKeyFromEnv();
   LiveBuilder& SetKey(std::string key);
   LiveBuilder& SetDataset(std::string dataset);
+  LiveBuilder& SetDataset(Dataset dataset);
   // Whether to append the gateway send timestamp after each DBN message.
   LiveBuilder& SetSendTsOut(bool send_ts_out);
   // Set the version upgrade policy for when receiving DBN data from a prior

--- a/include/databento/live.hpp
+++ b/include/databento/live.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <string>
 
 #include "databento/enums.hpp"  // VersionUpgradePolicy
@@ -29,6 +30,10 @@ class LiveBuilder {
   LiveBuilder& SetUpgradePolicy(VersionUpgradePolicy upgrade_policy);
   // Sets the receiver of the logs to be used by the client.
   LiveBuilder& SetLogReceiver(ILogReceiver* log_receiver);
+  // Overrides the heartbeat interval.
+  LiveBuilder& SetHeartbeatInterval(std::chrono::seconds heartbeat_interval);
+  // Overrides the gateway and port. This is an advanced method.
+  LiveBuilder& SetAddress(std::string gateway, std::uint16_t port);
   // Attempts to construct an instance of a blocking live client or throws an
   // exception.
   LiveBlocking BuildBlocking();
@@ -40,9 +45,12 @@ class LiveBuilder {
   void Validate();
 
   ILogReceiver* log_receiver_{};
+  std::string gateway_{};
+  std::uint16_t port_{};
   std::string key_;
   std::string dataset_;
   bool send_ts_out_{false};
   VersionUpgradePolicy upgrade_policy_{VersionUpgradePolicy::Upgrade};
+  std::chrono::seconds heartbeat_interval_{};
 };
 }  // namespace databento

--- a/include/databento/live_blocking.hpp
+++ b/include/databento/live_blocking.hpp
@@ -50,8 +50,8 @@ class LiveBlocking {
                  SType stype_in, UnixNanos start);
   void Subscribe(const std::vector<std::string>& symbols, Schema schema,
                  SType stype_in, const std::string& start);
-  void Subscribe(const std::vector<std::string>& symbols, Schema schema,
-                 SType stype_in, bool use_snapshot);
+  void SubscribeWithSnapshot(const std::vector<std::string>& symbols,
+                             Schema schema, SType stype_in);
   // Notifies the gateway to start sending messages for all subscriptions.
   //
   // This method should only be called once per instance.

--- a/include/databento/live_blocking.hpp
+++ b/include/databento/live_blocking.hpp
@@ -4,6 +4,7 @@
 #include <chrono>  // milliseconds
 #include <cstdint>
 #include <string>
+#include <utility>  // pair
 #include <vector>
 
 #include "databento/datetime.hpp"           // UnixNanos
@@ -22,10 +23,12 @@ class ILogReceiver;
 class LiveBlocking {
  public:
   LiveBlocking(ILogReceiver* log_receiver, std::string key, std::string dataset,
-               bool send_ts_out, VersionUpgradePolicy upgrade_policy);
+               bool send_ts_out, VersionUpgradePolicy upgrade_policy,
+               std::chrono::seconds heartbeat_interval);
   LiveBlocking(ILogReceiver* log_receiver, std::string key, std::string dataset,
                std::string gateway, std::uint16_t port, bool send_ts_out,
-               VersionUpgradePolicy upgrade_policy);
+               VersionUpgradePolicy upgrade_policy,
+               std::chrono::seconds heartbeat_interval);
   /*
    * Getters
    */
@@ -36,6 +39,11 @@ class LiveBlocking {
   std::uint16_t Port() const { return port_; }
   bool SendTsOut() const { return send_ts_out_; }
   VersionUpgradePolicy UpgradePolicy() const { return upgrade_policy_; }
+  // The the first member of the pair will be true, when the heartbeat interval
+  // was overridden.
+  std::pair<bool, std::chrono::seconds> HeartbeatInterval() const {
+    return {heartbeat_interval_.count() > 0, heartbeat_interval_};
+  }
 
   /*
    * Methods
@@ -95,6 +103,7 @@ class LiveBlocking {
   bool send_ts_out_;
   std::uint8_t version_{};
   VersionUpgradePolicy upgrade_policy_;
+  std::chrono::seconds heartbeat_interval_;
   detail::TcpClient client_;
   // Must be 8-byte aligned for records
   alignas(RecordHeader) std::array<char, kMaxStrLen> read_buffer_{};

--- a/include/databento/live_threaded.hpp
+++ b/include/databento/live_threaded.hpp
@@ -4,6 +4,7 @@
 #include <functional>  // function
 #include <memory>      // unique_ptr
 #include <string>
+#include <utility>  // pair
 #include <vector>
 
 #include "databento/datetime.hpp"              // UnixNanos
@@ -31,10 +32,12 @@ class LiveThreaded {
       std::function<ExceptionAction(const std::exception&)>;
 
   LiveThreaded(ILogReceiver* log_receiver, std::string key, std::string dataset,
-               bool send_ts_out, VersionUpgradePolicy upgrade_policy);
+               bool send_ts_out, VersionUpgradePolicy upgrade_policy,
+               std::chrono::seconds heartbeat_interval);
   LiveThreaded(ILogReceiver* log_receiver, std::string key, std::string dataset,
                std::string gateway, std::uint16_t port, bool send_ts_out,
-               VersionUpgradePolicy upgrade_policy);
+               VersionUpgradePolicy upgrade_policy,
+               std::chrono::seconds heartbeat_interval);
   LiveThreaded(const LiveThreaded&) = delete;
   LiveThreaded& operator=(const LiveThreaded&) = delete;
   LiveThreaded(LiveThreaded&& other) noexcept;
@@ -51,6 +54,9 @@ class LiveThreaded {
   std::uint16_t Port() const;
   bool SendTsOut() const;
   VersionUpgradePolicy UpgradePolicy() const;
+  // The the first member of the pair will be true, when the heartbeat interval
+  // was overridden.
+  std::pair<bool, std::chrono::seconds> HeartbeatInterval() const;
 
   /*
    * Methods

--- a/include/databento/live_threaded.hpp
+++ b/include/databento/live_threaded.hpp
@@ -65,8 +65,8 @@ class LiveThreaded {
                  SType stype_in, UnixNanos start);
   void Subscribe(const std::vector<std::string>& symbols, Schema schema,
                  SType stype_in, const std::string& start);
-  void Subscribe(const std::vector<std::string>& symbols, Schema schema,
-                 SType stype_in, bool use_snapshot);
+  void SubscribeWithSnapshot(const std::vector<std::string>& symbols,
+                             Schema schema, SType stype_in);
   // Notifies the gateway to start sending messages for all subscriptions.
   // `metadata_callback` will be called exactly once, before any calls to
   // `record_callback`. `record_callback` will be called for records from all

--- a/include/databento/metadata.hpp
+++ b/include/databento/metadata.hpp
@@ -32,8 +32,8 @@ struct DatasetConditionDetail {
 };
 
 struct DatasetRange {
-  std::string start_date;
-  std::string end_date;
+  std::string start;
+  std::string end;
 };
 
 inline bool operator==(const PublisherDetail& lhs, const PublisherDetail& rhs) {
@@ -71,7 +71,7 @@ inline bool operator!=(const DatasetConditionDetail& lhs,
 }
 
 inline bool operator==(const DatasetRange& lhs, const DatasetRange& rhs) {
-  return lhs.start_date == rhs.start_date && lhs.end_date == rhs.end_date;
+  return lhs.start == rhs.start && lhs.end == rhs.end;
 }
 inline bool operator!=(const DatasetRange& lhs, const DatasetRange& rhs) {
   return !(lhs == rhs);

--- a/include/databento/publishers.hpp
+++ b/include/databento/publishers.hpp
@@ -155,6 +155,8 @@ enum class Dataset : std::uint16_t {
   NdexImpact = 29,
   // Databento Equities Max
   DbeqMax = 30,
+  // Nasdaq Basic (NLS+QBBO)
+  XnasBasic = 31,
 };
 
 // A specific Venue from a specific data source.
@@ -265,9 +267,9 @@ enum class Publisher : std::uint16_t {
   DbeqPlusXnas = 52,
   // DBEQ Plus - NYSE
   DbeqPlusXnys = 53,
-  // DBEQ Plus - FINRA/NYSE TRF
-  DbeqPlusFinn = 54,
   // DBEQ Plus - FINRA/Nasdaq TRF Carteret
+  DbeqPlusFinn = 54,
+  // DBEQ Plus - FINRA/NYSE TRF
   DbeqPlusFiny = 55,
   // DBEQ Plus - FINRA/Nasdaq TRF Chicago
   DbeqPlusFinc = 56,
@@ -293,9 +295,9 @@ enum class Publisher : std::uint16_t {
   DbeqMaxXnas = 66,
   // DBEQ Max - NYSE
   DbeqMaxXnys = 67,
-  // DBEQ Max - FINRA/NYSE TRF
-  DbeqMaxFinn = 68,
   // DBEQ Max - FINRA/Nasdaq TRF Carteret
+  DbeqMaxFinn = 68,
+  // DBEQ Max - FINRA/NYSE TRF
   DbeqMaxFiny = 69,
   // DBEQ Max - FINRA/Nasdaq TRF Chicago
   DbeqMaxFinc = 70,
@@ -319,6 +321,12 @@ enum class Publisher : std::uint16_t {
   DbeqMaxArcx = 79,
   // DBEQ Max - Long-Term Stock Exchange
   DbeqMaxLtse = 80,
+  // Nasdaq Basic - Nasdaq
+  XnasBasicXnas = 81,
+  // Nasdaq Basic - FINRA/Nasdaq TRF Carteret
+  XnasBasicFinn = 82,
+  // Nasdaq Basic - FINRA/Nasdaq TRF Chicago
+  XnasBasicFinc = 83,
 };
 
 // Get a Publisher's Venue.

--- a/include/databento/publishers.hpp
+++ b/include/databento/publishers.hpp
@@ -91,6 +91,8 @@ enum class Venue : std::uint16_t {
   Sphr = 41,
   // Long-Term Stock Exchange, Inc.
   Ltse = 42,
+  // Off-Exchange Transactions - Listed Instruments
+  Xoff = 43,
 };
 
 // A source of data.
@@ -327,6 +329,10 @@ enum class Publisher : std::uint16_t {
   XnasBasicFinn = 82,
   // Nasdaq Basic - FINRA/Nasdaq TRF Chicago
   XnasBasicFinc = 83,
+  // ICE Futures Europe - Off-Market Trades
+  IfeuImpactXoff = 84,
+  // ICE Endex - Off-Market Trades
+  NdexImpactXoff = 85,
 };
 
 // Get a Publisher's Venue.

--- a/pkg/PKGBUILD
+++ b/pkg/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Databento <support@databento.com>
 _pkgname=databento-cpp
 pkgname=databento-cpp-git
-pkgver=0.18.1
+pkgver=0.19.0
 pkgrel=1
 pkgdesc="Official C++ client for Databento"
 arch=('any')

--- a/src/historical.cpp
+++ b/src/historical.cpp
@@ -559,9 +559,8 @@ databento::DatasetRange Historical::MetadataGetDatasetRange(
   if (!json.is_object()) {
     throw JsonResponseError::TypeMismatch(kEndpoint, "object", json);
   }
-  return DatasetRange{
-      detail::ParseAt<std::string>(kEndpoint, json, "start_date"),
-      detail::ParseAt<std::string>(kEndpoint, json, "end_date")};
+  return DatasetRange{detail::ParseAt<std::string>(kEndpoint, json, "start"),
+                      detail::ParseAt<std::string>(kEndpoint, json, "end")};
 }
 
 static const std::string kMetadataGetRecordCountEndpoint =

--- a/src/live.cpp
+++ b/src/live.cpp
@@ -35,6 +35,11 @@ LiveBuilder& LiveBuilder::SetDataset(std::string dataset) {
   return *this;
 }
 
+LiveBuilder& LiveBuilder::SetDataset(Dataset dataset) {
+  dataset_ = ToString(dataset);
+  return *this;
+}
+
 LiveBuilder& LiveBuilder::SetSendTsOut(bool send_ts_out) {
   send_ts_out_ = send_ts_out;
   return *this;

--- a/src/live.cpp
+++ b/src/live.cpp
@@ -1,5 +1,6 @@
 #include "databento/live.hpp"
 
+#include <chrono>
 #include <utility>  // move
 
 #include "databento/constants.hpp"      // kApiKeyLength
@@ -51,16 +52,40 @@ LiveBuilder& LiveBuilder::SetLogReceiver(
   return *this;
 }
 
+LiveBuilder& LiveBuilder::SetHeartbeatInterval(
+    std::chrono::seconds heartbeat_interval) {
+  heartbeat_interval_ = heartbeat_interval;
+  return *this;
+}
+
+LiveBuilder& LiveBuilder::SetAddress(std::string gateway, std::uint16_t port) {
+  gateway_ = std::move(gateway);
+  port_ = port;
+  return *this;
+}
+
 databento::LiveBlocking LiveBuilder::BuildBlocking() {
   Validate();
-  return databento::LiveBlocking{log_receiver_, key_, dataset_, send_ts_out_,
-                                 upgrade_policy_};
+  if (gateway_.empty()) {
+    return databento::LiveBlocking{log_receiver_,   key_,
+                                   dataset_,        send_ts_out_,
+                                   upgrade_policy_, heartbeat_interval_};
+  }
+  return databento::LiveBlocking{
+      log_receiver_, key_,         dataset_,        gateway_,
+      port_,         send_ts_out_, upgrade_policy_, heartbeat_interval_};
 }
 
 databento::LiveThreaded LiveBuilder::BuildThreaded() {
   Validate();
-  return databento::LiveThreaded{log_receiver_, key_, dataset_, send_ts_out_,
-                                 upgrade_policy_};
+  if (gateway_.empty()) {
+    return databento::LiveThreaded{log_receiver_,   key_,
+                                   dataset_,        send_ts_out_,
+                                   upgrade_policy_, heartbeat_interval_};
+  }
+  return databento::LiveThreaded{
+      log_receiver_, key_,         dataset_,        gateway_,
+      port_,         send_ts_out_, upgrade_policy_, heartbeat_interval_};
 }
 
 void LiveBuilder::Validate() {

--- a/src/live_blocking.cpp
+++ b/src/live_blocking.cpp
@@ -54,17 +54,14 @@ LiveBlocking::LiveBlocking(ILogReceiver* log_receiver, std::string key,
 
 void LiveBlocking::Subscribe(const std::vector<std::string>& symbols,
                              Schema schema, SType stype_in) {
-  Subscribe(symbols, schema, stype_in, UnixNanos{});
+  Subscribe(symbols, schema, stype_in, std::string{""});
 }
 
 void LiveBlocking::Subscribe(const std::vector<std::string>& symbols,
                              Schema schema, SType stype_in, UnixNanos start) {
   std::ostringstream sub_msg;
-  sub_msg << "schema=" << ToString(schema)
-          << "|stype_in=" << ToString(stype_in);
-  if (start.time_since_epoch().count()) {
-    sub_msg << "|start=" << start.time_since_epoch().count();
-  }
+  sub_msg << "schema=" << ToString(schema) << "|stype_in=" << ToString(stype_in)
+          << "|start=" << start.time_since_epoch().count();
   Subscribe(sub_msg.str(), symbols, false);
 }
 
@@ -80,13 +77,13 @@ void LiveBlocking::Subscribe(const std::vector<std::string>& symbols,
   Subscribe(sub_msg.str(), symbols, false);
 }
 
-void LiveBlocking::Subscribe(const std::vector<std::string>& symbols,
-                             Schema schema, SType stype_in, bool use_snapshot) {
+void LiveBlocking::SubscribeWithSnapshot(
+    const std::vector<std::string>& symbols, Schema schema, SType stype_in) {
   std::ostringstream sub_msg;
   sub_msg << "schema=" << ToString(schema)
           << "|stype_in=" << ToString(stype_in);
 
-  Subscribe(sub_msg.str(), symbols, use_snapshot);
+  Subscribe(sub_msg.str(), symbols, true);
 }
 
 void LiveBlocking::Subscribe(const std::string& sub_msg,

--- a/src/live_threaded.cpp
+++ b/src/live_threaded.cpp
@@ -57,16 +57,19 @@ LiveThreaded::~LiveThreaded() {
 
 LiveThreaded::LiveThreaded(ILogReceiver* log_receiver, std::string key,
                            std::string dataset, bool send_ts_out,
-                           VersionUpgradePolicy upgrade_policy)
+                           VersionUpgradePolicy upgrade_policy,
+                           std::chrono::seconds heartbeat_interval)
     : impl_{new Impl{log_receiver, std::move(key), std::move(dataset),
-                     send_ts_out, upgrade_policy}} {}
+                     send_ts_out, upgrade_policy, heartbeat_interval}} {}
 
 LiveThreaded::LiveThreaded(ILogReceiver* log_receiver, std::string key,
                            std::string dataset, std::string gateway,
                            std::uint16_t port, bool send_ts_out,
-                           VersionUpgradePolicy upgrade_policy)
+                           VersionUpgradePolicy upgrade_policy,
+                           std::chrono::seconds heartbeat_interval)
     : impl_{new Impl{log_receiver, std::move(key), std::move(dataset),
-                     std::move(gateway), port, send_ts_out, upgrade_policy}} {}
+                     std::move(gateway), port, send_ts_out, upgrade_policy,
+                     heartbeat_interval}} {}
 
 const std::string& LiveThreaded::Key() const { return impl_->blocking.Key(); }
 
@@ -84,6 +87,10 @@ bool LiveThreaded::SendTsOut() const { return impl_->blocking.SendTsOut(); }
 
 databento::VersionUpgradePolicy LiveThreaded::UpgradePolicy() const {
   return impl_->blocking.UpgradePolicy();
+}
+
+std::pair<bool, std::chrono::seconds> LiveThreaded::HeartbeatInterval() const {
+  return impl_->blocking.HeartbeatInterval();
 }
 
 void LiveThreaded::Subscribe(const std::vector<std::string>& symbols,

--- a/src/live_threaded.cpp
+++ b/src/live_threaded.cpp
@@ -102,9 +102,9 @@ void LiveThreaded::Subscribe(const std::vector<std::string>& symbols,
   impl_->blocking.Subscribe(symbols, schema, stype_in, start);
 }
 
-void LiveThreaded::Subscribe(const std::vector<std::string>& symbols,
-                             Schema schema, SType stype_in, bool use_snapshot) {
-  impl_->blocking.Subscribe(symbols, schema, stype_in, use_snapshot);
+void LiveThreaded::SubscribeWithSnapshot(
+    const std::vector<std::string>& symbols, Schema schema, SType stype_in) {
+  impl_->blocking.SubscribeWithSnapshot(symbols, schema, stype_in);
 }
 
 void LiveThreaded::Start(RecordCallback callback) {

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -59,8 +59,8 @@ std::ostream& operator<<(std::ostream& stream,
       .SetSpacer(" ")
       .SetTypeName("DatasetRange")
       .Build()
-      .AddField("start_date", dataset_range.start_date)
-      .AddField("end_date", dataset_range.end_date)
+      .AddField("start", dataset_range.start)
+      .AddField("end", dataset_range.end)
       .Finish();
 }
 }  // namespace databento

--- a/src/publishers.cpp
+++ b/src/publishers.cpp
@@ -372,6 +372,9 @@ const char* ToString(Dataset dataset) {
     case Dataset::DbeqMax: {
       return "DBEQ.MAX";
     }
+    case Dataset::XnasBasic: {
+      return "XNAS.BASIC";
+    }
     default: {
       return "Unknown";
     }
@@ -474,6 +477,9 @@ Dataset FromString(const std::string& str) {
   }
   if (str == "DBEQ.MAX") {
     return Dataset::DbeqMax;
+  }
+  if (str == "XNAS.BASIC") {
+    return Dataset::XnasBasic;
   }
   throw InvalidArgumentError{"FromString<Dataset>", "str",
                              "unknown value '" + str + '\''};
@@ -720,6 +726,15 @@ Venue PublisherVenue(Publisher publisher) {
     }
     case Publisher::DbeqMaxLtse: {
       return Venue::Ltse;
+    }
+    case Publisher::XnasBasicXnas: {
+      return Venue::Xnas;
+    }
+    case Publisher::XnasBasicFinn: {
+      return Venue::Finn;
+    }
+    case Publisher::XnasBasicFinc: {
+      return Venue::Finc;
     }
     default: {
       throw InvalidArgumentError{
@@ -971,6 +986,15 @@ Dataset PublisherDataset(Publisher publisher) {
     case Publisher::DbeqMaxLtse: {
       return Dataset::DbeqMax;
     }
+    case Publisher::XnasBasicXnas: {
+      return Dataset::XnasBasic;
+    }
+    case Publisher::XnasBasicFinn: {
+      return Dataset::XnasBasic;
+    }
+    case Publisher::XnasBasicFinc: {
+      return Dataset::XnasBasic;
+    }
     default: {
       throw InvalidArgumentError{
           "PublisherDataset", "publisher",
@@ -1221,6 +1245,15 @@ const char* ToString(Publisher publisher) {
     }
     case Publisher::DbeqMaxLtse: {
       return "DBEQ.MAX.LTSE";
+    }
+    case Publisher::XnasBasicXnas: {
+      return "XNAS.BASIC.XNAS";
+    }
+    case Publisher::XnasBasicFinn: {
+      return "XNAS.BASIC.FINN";
+    }
+    case Publisher::XnasBasicFinc: {
+      return "XNAS.BASIC.FINC";
     }
     default: {
       return "Unknown";
@@ -1474,6 +1507,15 @@ Publisher FromString(const std::string& str) {
   }
   if (str == "DBEQ.MAX.LTSE") {
     return Publisher::DbeqMaxLtse;
+  }
+  if (str == "XNAS.BASIC.XNAS") {
+    return Publisher::XnasBasicXnas;
+  }
+  if (str == "XNAS.BASIC.FINN") {
+    return Publisher::XnasBasicFinn;
+  }
+  if (str == "XNAS.BASIC.FINC") {
+    return Publisher::XnasBasicFinc;
   }
   throw InvalidArgumentError{"FromString<Publisher>", "str",
                              "unknown value '" + str + '\''};

--- a/src/publishers.cpp
+++ b/src/publishers.cpp
@@ -137,6 +137,9 @@ const char* ToString(Venue venue) {
     case Venue::Ltse: {
       return "LTSE";
     }
+    case Venue::Xoff: {
+      return "XOFF";
+    }
     default: {
       return "Unknown";
     }
@@ -275,6 +278,9 @@ Venue FromString(const std::string& str) {
   }
   if (str == "LTSE") {
     return Venue::Ltse;
+  }
+  if (str == "XOFF") {
+    return Venue::Xoff;
   }
   throw InvalidArgumentError{"FromString<Venue>", "str",
                              "unknown value '" + str + '\''};
@@ -736,6 +742,12 @@ Venue PublisherVenue(Publisher publisher) {
     case Publisher::XnasBasicFinc: {
       return Venue::Finc;
     }
+    case Publisher::IfeuImpactXoff: {
+      return Venue::Xoff;
+    }
+    case Publisher::NdexImpactXoff: {
+      return Venue::Xoff;
+    }
     default: {
       throw InvalidArgumentError{
           "PublisherVenue", "publisher",
@@ -994,6 +1006,12 @@ Dataset PublisherDataset(Publisher publisher) {
     }
     case Publisher::XnasBasicFinc: {
       return Dataset::XnasBasic;
+    }
+    case Publisher::IfeuImpactXoff: {
+      return Dataset::IfeuImpact;
+    }
+    case Publisher::NdexImpactXoff: {
+      return Dataset::NdexImpact;
     }
     default: {
       throw InvalidArgumentError{
@@ -1254,6 +1272,12 @@ const char* ToString(Publisher publisher) {
     }
     case Publisher::XnasBasicFinc: {
       return "XNAS.BASIC.FINC";
+    }
+    case Publisher::IfeuImpactXoff: {
+      return "IFEU.IMPACT.XOFF";
+    }
+    case Publisher::NdexImpactXoff: {
+      return "NDEX.IMPACT.XOFF";
     }
     default: {
       return "Unknown";
@@ -1516,6 +1540,12 @@ Publisher FromString(const std::string& str) {
   }
   if (str == "XNAS.BASIC.FINC") {
     return Publisher::XnasBasicFinc;
+  }
+  if (str == "IFEU.IMPACT.XOFF") {
+    return Publisher::IfeuImpactXoff;
+  }
+  if (str == "NDEX.IMPACT.XOFF") {
+    return Publisher::NdexImpactXoff;
   }
   throw InvalidArgumentError{"FromString<Publisher>", "str",
                              "unknown value '" + str + '\''};

--- a/test/include/mock/mock_lsg_server.hpp
+++ b/test/include/mock/mock_lsg_server.hpp
@@ -34,10 +34,11 @@ class MockLsgServer {
   void Accept();
   void Authenticate();
   void Subscribe(const std::vector<std::string>& symbols, Schema schema,
-                 SType stype, bool use_snapshot = false);
+                 SType stype);
   void Subscribe(const std::vector<std::string>& symbols, Schema schema,
-                 SType stype, const std::string& start,
-                 bool use_snapshot = false);
+                 SType stype, const std::string& start);
+  void SubscribeWithSnapshot(const std::vector<std::string>& symbols,
+                             Schema schema, SType stype);
   void Start();
   std::size_t Send(const std::string& msg);
   ::ssize_t UncheckedSend(const std::string& msg);

--- a/test/include/mock/mock_lsg_server.hpp
+++ b/test/include/mock/mock_lsg_server.hpp
@@ -10,6 +10,7 @@ using ssize_t = SSIZE_T;
 #include <sys/socket.h>  // send
 #endif
 
+#include <chrono>
 #include <condition_variable>
 #include <functional>  // function
 #include <mutex>
@@ -27,6 +28,9 @@ namespace mock {
 class MockLsgServer {
  public:
   MockLsgServer(std::string dataset, bool ts_out,
+                std::function<void(MockLsgServer&)> serve_fn);
+  MockLsgServer(std::string dataset, bool ts_out,
+                std::chrono::seconds heartbeat_interval,
                 std::function<void(MockLsgServer&)> serve_fn);
 
   std::uint16_t Port() const { return port_; }
@@ -83,6 +87,7 @@ class MockLsgServer {
 
   std::string dataset_;
   bool ts_out_;
+  std::chrono::seconds heartbeat_interval_;
   std::uint16_t port_{};
   detail::ScopedFd socket_{};
   detail::ScopedFd conn_fd_{};

--- a/test/src/historical_tests.cpp
+++ b/test/src/historical_tests.cpp
@@ -447,8 +447,8 @@ TEST_F(HistoricalTests, TestMetadataListUnitPrices) {
 }
 
 TEST_F(HistoricalTests, TestMetadataGetDatasetRange) {
-  const nlohmann::json kResp = {{"start_date", "2017-05-21"},
-                                {"end_date", "2022-12-01"}};
+  const nlohmann::json kResp = {{"start", "2017-05-21T00:00:00.000000000Z"},
+                                {"end", "2022-12-01T00:00:00.000000000Z"}};
   mock_server_.MockGetJson("/v0/metadata.get_dataset_range",
                            {{"dataset", dataset::kXnasItch}}, kResp);
   const auto port = mock_server_.ListenOnThread();
@@ -456,8 +456,8 @@ TEST_F(HistoricalTests, TestMetadataGetDatasetRange) {
   databento::Historical target{logger_.get(), kApiKey, "localhost",
                                static_cast<std::uint16_t>(port)};
   const auto res = target.MetadataGetDatasetRange(dataset::kXnasItch);
-  EXPECT_EQ(res.start_date, "2017-05-21");
-  EXPECT_EQ(res.end_date, "2022-12-01");
+  EXPECT_EQ(res.start, "2017-05-21T00:00:00.000000000Z");
+  EXPECT_EQ(res.end, "2022-12-01T00:00:00.000000000Z");
 }
 
 TEST_F(HistoricalTests, TestMetadataGetRecordCount) {

--- a/test/src/live_blocking_tests.cpp
+++ b/test/src/live_blocking_tests.cpp
@@ -13,6 +13,7 @@
 #include "databento/datetime.hpp"
 #include "databento/enums.hpp"  // Schema, SType
 #include "databento/exceptions.hpp"
+#include "databento/live.hpp"
 #include "databento/live_blocking.hpp"
 #include "databento/log.hpp"
 #include "databento/record.hpp"
@@ -34,23 +35,28 @@ class LiveBlockingTests : public testing::Test {
   static constexpr auto kLocalhost = "127.0.0.1";
 
   std::unique_ptr<ILogReceiver> logger_{new NullLogReceiver};
+  LiveBuilder builder_{
+      LiveBuilder{}.SetLogReceiver(logger_.get()).SetKey(kKey)};
 };
 
 TEST_F(LiveBlockingTests, TestAuthentication) {
   constexpr auto kTsOut = false;
+  constexpr auto kHeartbeatInterval = std::chrono::seconds{10};
   const mock::MockLsgServer mock_server{dataset::kXnasItch, kTsOut,
+                                        kHeartbeatInterval,
                                         [](mock::MockLsgServer& self) {
                                           self.Accept();
                                           self.Authenticate();
                                         }};
 
-  const LiveBlocking target{
-      logger_.get(),      kKey,   dataset::kXnasItch,    kLocalhost,
-      mock_server.Port(), kTsOut, VersionUpgradePolicy{}};
+  const LiveBlocking target = builder_.SetDataset(dataset::kXnasItch)
+                                  .SetHeartbeatInterval(kHeartbeatInterval)
+                                  .SetAddress(kLocalhost, mock_server.Port())
+                                  .BuildBlocking();
 }
 
 TEST_F(LiveBlockingTests, TestStart) {
-  constexpr auto kTsOut = false;
+  constexpr auto kTsOut = true;
   const mock::MockLsgServer mock_server{dataset::kGlbxMdp3, kTsOut,
                                         [](mock::MockLsgServer& self) {
                                           self.Accept();
@@ -58,9 +64,10 @@ TEST_F(LiveBlockingTests, TestStart) {
                                           self.Start();
                                         }};
 
-  LiveBlocking target{
-      logger_.get(),      kKey,   dataset::kGlbxMdp3,    kLocalhost,
-      mock_server.Port(), kTsOut, VersionUpgradePolicy{}};
+  LiveBlocking target = builder_.SetAddress(kLocalhost, mock_server.Port())
+                            .SetSendTsOut(kTsOut)
+                            .SetDataset(dataset::kGlbxMdp3)
+                            .BuildBlocking();
   const auto metadata = target.Start();
   EXPECT_EQ(metadata.version, 1);
   EXPECT_TRUE(metadata.has_mixed_schema);
@@ -82,13 +89,10 @@ TEST_F(LiveBlockingTests, TestSubscribe) {
         self.Subscribe(kSymbols, kSchema, kSType);
       }};
 
-  LiveBlocking target{logger_.get(),
-                      kKey,
-                      kDataset,
-                      kLocalhost,
-                      mock_server.Port(),
-                      kTsOut,
-                      VersionUpgradePolicy{}};
+  LiveBlocking target = builder_.SetDataset(kDataset)
+                            .SetSendTsOut(kTsOut)
+                            .SetAddress(kLocalhost, mock_server.Port())
+                            .BuildBlocking();
   target.Subscribe(kSymbols, kSchema, kSType);
 }
 
@@ -115,13 +119,10 @@ TEST_F(LiveBlockingTests, TestSubscriptionChunkingUnixNanos) {
         }
       }};
 
-  LiveBlocking target{logger_.get(),
-                      kKey,
-                      kDataset,
-                      kLocalhost,
-                      mock_server.Port(),
-                      kTsOut,
-                      VersionUpgradePolicy{}};
+  LiveBlocking target = builder_.SetDataset(kDataset)
+                            .SetSendTsOut(kTsOut)
+                            .SetAddress(kLocalhost, mock_server.Port())
+                            .BuildBlocking();
   const std::vector<std::string> kSymbols(kSymbolCount, kSymbol);
   target.Subscribe(kSymbols, kSchema, kSType);
 }
@@ -143,13 +144,10 @@ TEST_F(LiveBlockingTests, TestSubscriptionUnixNanos0) {
         self.Subscribe(kSymbols, kSchema, kSType, "0");
       }};
 
-  LiveBlocking target{logger_.get(),
-                      kKey,
-                      kDataset,
-                      kLocalhost,
-                      mock_server.Port(),
-                      kTsOut,
-                      VersionUpgradePolicy{}};
+  LiveBlocking target = builder_.SetDataset(kDataset)
+                            .SetSendTsOut(kTsOut)
+                            .SetAddress(kLocalhost, mock_server.Port())
+                            .BuildBlocking();
   target.Subscribe(kSymbols, kSchema, kSType, kStart);
 }
 
@@ -178,13 +176,10 @@ TEST_F(LiveBlockingTests, TestSubscriptionChunkingStringStart) {
         }
       }};
 
-  LiveBlocking target{logger_.get(),
-                      kKey,
-                      kDataset,
-                      kLocalhost,
-                      mock_server.Port(),
-                      kTsOut,
-                      VersionUpgradePolicy{}};
+  LiveBlocking target = builder_.SetDataset(kDataset)
+                            .SetSendTsOut(kTsOut)
+                            .SetAddress(kLocalhost, mock_server.Port())
+                            .BuildBlocking();
   const std::vector<std::string> kSymbols(kSymbolCount, kSymbol);
   target.Subscribe(kSymbols, kSchema, kSType, kStart);
 }
@@ -214,13 +209,10 @@ TEST_F(LiveBlockingTests, TestSubscribeSnapshot) {
         }
       }};
 
-  LiveBlocking target{logger_.get(),
-                      kKey,
-                      kDataset,
-                      kLocalhost,
-                      mock_server.Port(),
-                      kTsOut,
-                      VersionUpgradePolicy{}};
+  LiveBlocking target = builder_.SetDataset(kDataset)
+                            .SetSendTsOut(kTsOut)
+                            .SetAddress(kLocalhost, mock_server.Port())
+                            .BuildBlocking();
   const std::vector<std::string> kSymbols(kSymbolCount, kSymbol);
   target.SubscribeWithSnapshot(kSymbols, kSchema, kSType);
 }
@@ -238,13 +230,10 @@ TEST_F(LiveBlockingTests, TestInvalidSubscription) {
                                           self.Authenticate();
                                         }};
 
-  LiveBlocking target{logger_.get(),
-                      kKey,
-                      kDataset,
-                      kLocalhost,
-                      mock_server.Port(),
-                      kTsOut,
-                      VersionUpgradePolicy{}};
+  LiveBlocking target = builder_.SetDataset(kDataset)
+                            .SetSendTsOut(kTsOut)
+                            .SetAddress(kLocalhost, mock_server.Port())
+                            .BuildBlocking();
 
   ASSERT_THROW(target.Subscribe(kNoSymbols, kSchema, kSType),
                databento::InvalidArgumentError);
@@ -263,9 +252,10 @@ TEST_F(LiveBlockingTests, TestNextRecord) {
         }
       }};
 
-  LiveBlocking target{
-      logger_.get(),      kKey,   dataset::kXnasItch,    kLocalhost,
-      mock_server.Port(), kTsOut, VersionUpgradePolicy{}};
+  LiveBlocking target = builder_.SetDataset(dataset::kXnasItch)
+                            .SetSendTsOut(kTsOut)
+                            .SetAddress(kLocalhost, mock_server.Port())
+                            .BuildBlocking();
   for (size_t i = 0; i < kRecCount; ++i) {
     const auto rec = target.NextRecord();
     ASSERT_TRUE(rec.Holds<OhlcvMsg>()) << "Failed on call " << i;
@@ -314,9 +304,10 @@ TEST_F(LiveBlockingTests, TestNextRecordTimeout) {
         self.SendRecord(kRec);
       }};
 
-  LiveBlocking target{
-      logger_.get(),      kKey,   dataset::kXnasItch,    kLocalhost,
-      mock_server.Port(), kTsOut, VersionUpgradePolicy{}};
+  LiveBlocking target = builder_.SetDataset(dataset::kXnasItch)
+                            .SetSendTsOut(kTsOut)
+                            .SetAddress(kLocalhost, mock_server.Port())
+                            .BuildBlocking();
   {
     // wait for server to send first record to avoid flaky timeouts
     std::unique_lock<std::mutex> lock{send_mutex};
@@ -369,9 +360,10 @@ TEST_F(LiveBlockingTests, TestNextRecordPartialRead) {
                              send_remaining_cv);
       }};
 
-  LiveBlocking target{
-      logger_.get(),      kKey,   dataset::kGlbxMdp3,    kLocalhost,
-      mock_server.Port(), kTsOut, VersionUpgradePolicy{}};
+  LiveBlocking target = builder_.SetDataset(dataset::kGlbxMdp3)
+                            .SetSendTsOut(kTsOut)
+                            .SetAddress(kLocalhost, mock_server.Port())
+                            .BuildBlocking();
   auto rec = target.NextRecord();
   ASSERT_TRUE(rec.Holds<MboMsg>());
   EXPECT_EQ(rec.Get<MboMsg>(), kRec);
@@ -414,9 +406,10 @@ TEST_F(LiveBlockingTests, TestNextRecordWithTsOut) {
         }
       }};
 
-  LiveBlocking target{
-      logger_.get(),      kKey,   dataset::kXnasItch,    kLocalhost,
-      mock_server.Port(), kTsOut, VersionUpgradePolicy{}};
+  LiveBlocking target = builder_.SetDataset(dataset::kXnasItch)
+                            .SetSendTsOut(kTsOut)
+                            .SetAddress(kLocalhost, mock_server.Port())
+                            .BuildBlocking();
   for (size_t i = 0; i < kRecCount; ++i) {
     const auto rec = target.NextRecord();
     ASSERT_TRUE(rec.Holds<WithTsOut<TradeMsg>>()) << "Failed on call " << i;
@@ -460,9 +453,10 @@ TEST_F(LiveBlockingTests, TestStop) {
           }}  // namespace test
   };  // namespace databento
 
-  LiveBlocking target{
-      logger_.get(),       kKey,   dataset::kXnasItch,    kLocalhost,
-      mock_server->Port(), kTsOut, VersionUpgradePolicy{}};
+  LiveBlocking target = builder_.SetDataset(dataset::kXnasItch)
+                            .SetSendTsOut(kTsOut)
+                            .SetAddress(kLocalhost, mock_server->Port())
+                            .BuildBlocking();
   ASSERT_EQ(target.NextRecord().Get<WithTsOut<TradeMsg>>(), send_rec);
   target.Stop();
   has_stopped = true;
@@ -472,10 +466,8 @@ TEST_F(LiveBlockingTests, TestStop) {
 }
 
 TEST_F(LiveBlockingTests, TestConnectWhenGatewayNotUp) {
-  constexpr auto kTsOut = true;
-  ASSERT_THROW(LiveBlocking(logger_.get(), kKey, dataset::kXnasItch, kLocalhost,
-                            80, kTsOut, VersionUpgradePolicy{}),
-               databento::TcpError);
+  builder_.SetDataset(dataset::kXnasItch).SetAddress(kLocalhost, 80);
+  ASSERT_THROW(builder_.BuildBlocking(), databento::TcpError);
 }
 
 TEST_F(LiveBlockingTests, TestReconnect) {
@@ -521,9 +513,11 @@ TEST_F(LiveBlockingTests, TestReconnect) {
         self.Start();
         self.SendRecord(kRec);
       }}};
-  LiveBlocking target{
-      logger_.get(),       kKey,   dataset::kXnasItch,    kLocalhost,
-      mock_server->Port(), kTsOut, VersionUpgradePolicy{}};
+  LiveBlocking target = builder_.SetDataset(dataset::kXnasItch)
+                            .SetSendTsOut(kTsOut)
+                            .SetAddress(kLocalhost, mock_server->Port())
+                            .BuildBlocking();
+
   // Tell server to close connection
   {
     const std::lock_guard<std::mutex> _lock{should_close_mutex};

--- a/test/src/live_threaded_tests.cpp
+++ b/test/src/live_threaded_tests.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <exception>
 #include <iostream>
@@ -12,6 +13,7 @@
 #include "databento/dbn.hpp"
 #include "databento/enums.hpp"
 #include "databento/exceptions.hpp"
+#include "databento/live.hpp"
 #include "databento/live_threaded.hpp"
 #include "databento/log.hpp"
 #include "databento/record.hpp"
@@ -35,6 +37,8 @@ class LiveThreadedTests : public testing::Test {
   static constexpr auto kLocalhost = "127.0.0.1";
 
   std::unique_ptr<ILogReceiver> logger_{new NullLogReceiver};
+  LiveBuilder builder_{
+      LiveBuilder{}.SetLogReceiver(logger_.get()).SetKey(kKey)};
 };
 
 TEST_F(LiveThreadedTests, TestBasic) {
@@ -49,7 +53,9 @@ TEST_F(LiveThreadedTests, TestBasic) {
                     UnixNanos{},
                     TimeDeltaNanos{},
                     100};
+  constexpr auto kHeartbeatInterval = std::chrono::seconds{5};
   const mock::MockLsgServer mock_server{dataset::kGlbxMdp3, kTsOut,
+                                        kHeartbeatInterval,
                                         [&kRec](mock::MockLsgServer& self) {
                                           self.Accept();
                                           self.Authenticate();
@@ -58,9 +64,11 @@ TEST_F(LiveThreadedTests, TestBasic) {
                                           self.SendRecord(kRec);
                                         }};
 
-  LiveThreaded target{
-      logger_.get(),      kKey,   dataset::kGlbxMdp3,    kLocalhost,
-      mock_server.Port(), kTsOut, VersionUpgradePolicy{}};
+  LiveThreaded target = builder_.SetDataset(dataset::kGlbxMdp3)
+                            .SetSendTsOut(kTsOut)
+                            .SetHeartbeatInterval(kHeartbeatInterval)
+                            .SetAddress(kLocalhost, mock_server.Port())
+                            .BuildThreaded();
   std::uint32_t call_count{};
   target.Start([&call_count, &kRec](const Record& rec) {
     ++call_count;
@@ -99,9 +107,10 @@ TEST_F(LiveThreadedTests, TestTimeoutRecovery) {
         self.SendRecord(kRec);
       }};
 
-  LiveThreaded target{
-      logger_.get(),      kKey,  dataset::kXnasItch,    kLocalhost,
-      mock_server.Port(), false, VersionUpgradePolicy{}};
+  LiveThreaded target = builder_.SetDataset(dataset::kXnasItch)
+                            .SetSendTsOut(kTsOut)
+                            .SetAddress(kLocalhost, mock_server.Port())
+                            .BuildThreaded();
   target.Start(
       [](Metadata&& metadata) { EXPECT_TRUE(metadata.has_mixed_schema); },
       [&call_count, &kRec](const Record& rec) {
@@ -147,9 +156,10 @@ TEST_F(LiveThreadedTests, TestStop) {
         }
       }}};
 
-  LiveThreaded target{
-      logger_.get(),       kKey,   dataset::kXnasItch,    kLocalhost,
-      mock_server->Port(), kTsOut, VersionUpgradePolicy{}};
+  LiveThreaded target = builder_.SetDataset(dataset::kXnasItch)
+                            .SetSendTsOut(kTsOut)
+                            .SetAddress(kLocalhost, mock_server->Port())
+                            .BuildThreaded();
   target.Start(
       [](Metadata&& metadata) { EXPECT_TRUE(metadata.has_mixed_schema); },
       [&call_count, &kRec](const Record& rec) {
@@ -202,9 +212,10 @@ TEST_F(LiveThreadedTests, TestExceptionCallbackAndReconnect) {
         self.Start();
         self.SendRecord(kRec);
       }};
-  LiveThreaded target{
-      logger_.get(),      kKey,   dataset::kXnasItch,    kLocalhost,
-      mock_server.Port(), kTsOut, VersionUpgradePolicy{}};
+  LiveThreaded target = builder_.SetDataset(dataset::kXnasItch)
+                            .SetSendTsOut(kTsOut)
+                            .SetAddress(kLocalhost, mock_server.Port())
+                            .BuildThreaded();
   std::atomic<std::int32_t> metadata_calls{};
   const auto metadata_cb = [&metadata_calls, &should_close, &should_close_cv,
                             &should_close_mutex](Metadata&& metadata) {
@@ -271,9 +282,11 @@ TEST_F(LiveThreadedTests, TestDeadlockPrevention) {
         self.Authenticate();
         self.Subscribe(kSymbols, kSchema, kSType);
       }};
-  LiveThreaded target{
-      ILogReceiver::Default(), kKey,   dataset::kXnasItch,    kLocalhost,
-      mock_server.Port(),      kTsOut, VersionUpgradePolicy{}};
+  LiveThreaded target = builder_.SetLogReceiver(ILogReceiver::Default())
+                            .SetDataset(dataset::kXnasItch)
+                            .SetSendTsOut(kTsOut)
+                            .SetAddress(kLocalhost, mock_server.Port())
+                            .BuildThreaded();
   std::atomic<std::int32_t> metadata_calls{};
   const auto metadata_cb = [&metadata_calls, &should_close, &should_close_cv,
                             &should_close_mutex](Metadata&&) {
@@ -318,9 +331,10 @@ TEST_F(LiveThreadedTests, TestBlockForStopTimeout) {
                                           self.Start();
                                           self.SendRecord(kRec);
                                         }};
-  LiveThreaded target{
-      ILogReceiver::Default(), kKey,   dataset::kXnasItch,    kLocalhost,
-      mock_server.Port(),      kTsOut, VersionUpgradePolicy{}};
+  LiveThreaded target = builder_.SetDataset(dataset::kXnasItch)
+                            .SetSendTsOut(kTsOut)
+                            .SetAddress(kLocalhost, mock_server.Port())
+                            .BuildThreaded();
   target.Start([](const Record&) { return KeepGoing::Continue; });
   ASSERT_EQ(target.BlockForStop(std::chrono::milliseconds{100}),
             KeepGoing::Continue);

--- a/test/src/live_threaded_tests.cpp
+++ b/test/src/live_threaded_tests.cpp
@@ -188,7 +188,7 @@ TEST_F(LiveThreadedTests, TestExceptionCallbackAndReconnect) {
        kSType, kUseSnapshot](mock::MockLsgServer& self) {
         self.Accept();
         self.Authenticate();
-        self.Subscribe(kAllSymbols, kSchema, kSType, kUseSnapshot);
+        self.SubscribeWithSnapshot(kAllSymbols, kSchema, kSType);
         self.Start();
         {
           std::unique_lock<std::mutex> shutdown_lock{should_close_mutex};
@@ -237,7 +237,7 @@ TEST_F(LiveThreadedTests, TestExceptionCallbackAndReconnect) {
     }
   };
 
-  target.Subscribe(kAllSymbols, kSchema, kSType, kUseSnapshot);
+  target.SubscribeWithSnapshot(kAllSymbols, kSchema, kSType);
   target.Start(metadata_cb, record_cb, exception_cb);
   target.BlockForStop();
   EXPECT_EQ(metadata_calls, 2);

--- a/test/src/metadata_tests.cpp
+++ b/test/src/metadata_tests.cpp
@@ -14,10 +14,11 @@ TEST(MetadataTests, TestDatasetConditionDetailToString) {
 }
 
 TEST(MetadataTests, TestDatasetRangeToString) {
-  const DatasetRange target{"2022-05-17", "2023-01-07"};
+  const DatasetRange target{"2022-05-17T00:00:00.000000000Z",
+                            "2023-01-07T00:00:00.000000000Z"};
   ASSERT_EQ(
       ToString(target),
-      R"(DatasetRange { start_date = "2022-05-17", end_date = "2023-01-07" })");
+      R"(DatasetRange { start = "2022-05-17T00:00:00.000000000Z", end = "2023-01-07T00:00:00.000000000Z" })");
 }
 }  // namespace test
 }  // namespace databento

--- a/test/src/mock_lsg_server.cpp
+++ b/test/src/mock_lsg_server.cpp
@@ -91,13 +91,28 @@ void MockLsgServer::Authenticate() {
 }
 
 void MockLsgServer::Subscribe(const std::vector<std::string>& symbols,
-                              Schema schema, SType stype, bool use_snapshot) {
-  Subscribe(symbols, schema, stype, {}, use_snapshot);
+                              Schema schema, SType stype) {
+  Subscribe(symbols, schema, stype, "");
+}
+
+void MockLsgServer::SubscribeWithSnapshot(
+    const std::vector<std::string>& symbols, Schema schema, SType stype) {
+  const auto received = Receive();
+  EXPECT_NE(
+      received.find("symbols=" +
+                    JoinSymbolStrings("MockLsgServer::Subscribe", symbols)),
+      std::string::npos);
+  EXPECT_NE(received.find(std::string{"schema="} + ToString(schema)),
+            std::string::npos);
+  EXPECT_NE(received.find(std::string{"stype_in="} + ToString(stype)),
+            std::string::npos);
+  EXPECT_EQ(received.find("start="), std::string::npos);
+  EXPECT_NE(received.find("snapshot=1"), std::string::npos);
 }
 
 void MockLsgServer::Subscribe(const std::vector<std::string>& symbols,
                               Schema schema, SType stype,
-                              const std::string& start, bool use_snapshot) {
+                              const std::string& start) {
   const auto received = Receive();
   EXPECT_NE(
       received.find("symbols=" +
@@ -108,14 +123,11 @@ void MockLsgServer::Subscribe(const std::vector<std::string>& symbols,
   EXPECT_NE(received.find(std::string{"stype_in="} + ToString(stype)),
             std::string::npos);
   if (start.empty()) {
-    EXPECT_EQ(received.find(std::string{"start="}), std::string::npos);
+    EXPECT_EQ(received.find("start="), std::string::npos);
   } else {
     EXPECT_NE(received.find(std::string{"start="} + start), std::string::npos);
   }
-
-  EXPECT_NE(
-      received.find(std::string{"snapshot="} + std::to_string(use_snapshot)),
-      std::string::npos);
+  EXPECT_NE(received.find("snapshot=0"), std::string::npos);
 }
 
 void MockLsgServer::Start() {


### PR DESCRIPTION
##### Enhancements
- Added configurable `heartbeat_interval` parameter for live clients that determines the
  timeout before heartbeat `SystemMsg` records will be sent. It can be configured via
  the `SetHeartbeatInterval` method of the `LiveBuilder`
- Added `SetAddress` method to `LiveBuilder` for configuring a custom gateway address
  without using the constructor directly
- Added new `UncrossingPrice` `StatType` variant
- Added new publisher values for `XNAS.BASIC`
- Added `SetDataset(Dataset)` overload to `LiveBuilder`

##### Breaking changes
- Added `heartbeat_interval` parameter to the `Live` constructors
- Removed `start_date` and `end_date` fields from `DatasetRange` struct
  in favor of `start` and `end`
- Removed live `Subscribe` method overloads with `use_snapshot`
  parameter in favor of separate `SubscribeWithSnapshot` method

##### Bug fixes
- Fixed overloading of live `Subscribe` methods
- Fixed live subscribing with default-constructed `UnixNanos`
- Fixed descriptions for `FINN` and `FINY` publishers.