### PR TITLE
VER: Release 0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.19.1 - TBD
+## 0.19.1 - 2024-06-25
 
 ### Enhancements
 - Added `Upgrade()` method to `Metadata` to update the metadata fields according to a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.19.1 - TBD
+
+### Enhancements
+- Added new publisher values for `XNAS.BASIC` and `XNAS.NLS`
+
 ## 0.19.0 - 2024-06-04
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 ## 0.19.1 - TBD
 
 ### Enhancements
+- Added `Upgrade()` method to `Metadata` to update the metadata fields according to a
+  `VersionUpgradePolicy`
 - Added new publisher values for `XNAS.BASIC` and `XNAS.NLS`
+
+### Bug fixes
+- Fixed issue where `Metadata` wasn't upgraded when passing
+  `VersionUpgradePolicy::Upgrade`
 
 ## 0.19.0 - 2024-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 ### Bug fixes
 - Fixed overloading of live `Subscribe` methods
 - Fixed live subscribing with default-constructed `UnixNanos`
-- Fixed descriptions for `FINN` and `FINY` publishers.
+- Fixed descriptions for `FINN` and `FINY` publishers
 
 ## 0.18.1 - 2024-05-22
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.14)
 # Project details
 #
 
-project("databento" VERSION 0.19.0 LANGUAGES CXX)
+project("databento" VERSION 0.19.1 LANGUAGES CXX)
 string(TOUPPER ${PROJECT_NAME} PROJECT_NAME_UPPERCASE)
 
 #

--- a/include/databento/dbn.hpp
+++ b/include/databento/dbn.hpp
@@ -68,6 +68,9 @@ struct Metadata {
   std::vector<std::string> not_found;
   // Symbol mappings containing a native symbol and its mapping intervals.
   std::vector<SymbolMapping> mappings;
+
+  // Upgrades the metadata according to `upgrade_policy` if necessary.
+  void Upgrade(VersionUpgradePolicy upgrade_policy);
 };
 
 inline bool operator==(const MappingInterval& lhs, const MappingInterval& rhs) {

--- a/include/databento/publishers.hpp
+++ b/include/databento/publishers.hpp
@@ -333,6 +333,14 @@ enum class Publisher : std::uint16_t {
   IfeuImpactXoff = 84,
   // ICE Endex - Off-Market Trades
   NdexImpactXoff = 85,
+  // Nasdaq NLS - Nasdaq BX
+  XnasNlsXbos = 86,
+  // Nasdaq NLS - Nasdaq PSX
+  XnasNlsXpsx = 87,
+  // Nasdaq Basic - Nasdaq BX
+  XnasBasicXbos = 88,
+  // Nasdaq Basic - Nasdaq PSX
+  XnasBasicXpsx = 89,
 };
 
 // Get a Publisher's Venue.

--- a/pkg/PKGBUILD
+++ b/pkg/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Databento <support@databento.com>
 _pkgname=databento-cpp
 pkgname=databento-cpp-git
-pkgver=0.19.0
+pkgver=0.19.1
 pkgrel=1
 pkgdesc="Official C++ client for Databento"
 arch=('any')

--- a/src/dbn.cpp
+++ b/src/dbn.cpp
@@ -2,11 +2,20 @@
 
 #include <array>
 #include <sstream>  // ostringstream
-#include <utility>  // pair
 
+#include "databento/constants.hpp"
 #include "stream_op_helper.hpp"
 
 namespace databento {
+
+void Metadata::Upgrade(VersionUpgradePolicy upgrade_policy) {
+  if (version < kDbnVersion &&
+      upgrade_policy == VersionUpgradePolicy::Upgrade) {
+    version = kDbnVersion;
+    symbol_cstr_len = kSymbolCstrLen;
+  }
+}
+
 std::string ToString(const Metadata& metadata) { return MakeString(metadata); }
 std::ostream& operator<<(std::ostream& stream, const Metadata& metadata) {
   auto helper = StreamOpBuilder{stream}

--- a/src/dbn_decoder.cpp
+++ b/src/dbn_decoder.cpp
@@ -191,6 +191,7 @@ databento::Metadata DbnDecoder::DecodeMetadata() {
   buffer_idx_ = read_buffer_.size();
   auto metadata = DbnDecoder::DecodeMetadataFields(version_, read_buffer_);
   ts_out_ = metadata.ts_out;
+  metadata.Upgrade(upgrade_policy_);
   return metadata;
 }
 

--- a/src/live_blocking.cpp
+++ b/src/live_blocking.cpp
@@ -130,6 +130,7 @@ databento::Metadata LiveBlocking::Start() {
   auto metadata =
       DbnDecoder::DecodeMetadataFields(version_and_size.first, meta_buffer);
   version_ = metadata.version;
+  metadata.Upgrade(upgrade_policy_);
   return metadata;
 }
 

--- a/src/publishers.cpp
+++ b/src/publishers.cpp
@@ -748,6 +748,18 @@ Venue PublisherVenue(Publisher publisher) {
     case Publisher::NdexImpactXoff: {
       return Venue::Xoff;
     }
+    case Publisher::XnasNlsXbos: {
+      return Venue::Xbos;
+    }
+    case Publisher::XnasNlsXpsx: {
+      return Venue::Xpsx;
+    }
+    case Publisher::XnasBasicXbos: {
+      return Venue::Xbos;
+    }
+    case Publisher::XnasBasicXpsx: {
+      return Venue::Xpsx;
+    }
     default: {
       throw InvalidArgumentError{
           "PublisherVenue", "publisher",
@@ -1012,6 +1024,18 @@ Dataset PublisherDataset(Publisher publisher) {
     }
     case Publisher::NdexImpactXoff: {
       return Dataset::NdexImpact;
+    }
+    case Publisher::XnasNlsXbos: {
+      return Dataset::XnasNls;
+    }
+    case Publisher::XnasNlsXpsx: {
+      return Dataset::XnasNls;
+    }
+    case Publisher::XnasBasicXbos: {
+      return Dataset::XnasBasic;
+    }
+    case Publisher::XnasBasicXpsx: {
+      return Dataset::XnasBasic;
     }
     default: {
       throw InvalidArgumentError{
@@ -1278,6 +1302,18 @@ const char* ToString(Publisher publisher) {
     }
     case Publisher::NdexImpactXoff: {
       return "NDEX.IMPACT.XOFF";
+    }
+    case Publisher::XnasNlsXbos: {
+      return "XNAS.NLS.XBOS";
+    }
+    case Publisher::XnasNlsXpsx: {
+      return "XNAS.NLS.XPSX";
+    }
+    case Publisher::XnasBasicXbos: {
+      return "XNAS.BASIC.XBOS";
+    }
+    case Publisher::XnasBasicXpsx: {
+      return "XNAS.BASIC.XPSX";
     }
     default: {
       return "Unknown";
@@ -1546,6 +1582,18 @@ Publisher FromString(const std::string& str) {
   }
   if (str == "NDEX.IMPACT.XOFF") {
     return Publisher::NdexImpactXoff;
+  }
+  if (str == "XNAS.NLS.XBOS") {
+    return Publisher::XnasNlsXbos;
+  }
+  if (str == "XNAS.NLS.XPSX") {
+    return Publisher::XnasNlsXpsx;
+  }
+  if (str == "XNAS.BASIC.XBOS") {
+    return Publisher::XnasBasicXbos;
+  }
+  if (str == "XNAS.BASIC.XPSX") {
+    return Publisher::XnasBasicXpsx;
   }
   throw InvalidArgumentError{"FromString<Publisher>", "str",
                              "unknown value '" + str + '\''};

--- a/test/src/dbn_decoder_tests.cpp
+++ b/test/src/dbn_decoder_tests.cpp
@@ -109,7 +109,7 @@ TEST_F(DbnDecoderTests, TestDecodeDefinitionUpgrade) {
   const Metadata ch_metadata = channel_target_->DecodeMetadata();
   const Metadata f_metadata = file_target_->DecodeMetadata();
   EXPECT_EQ(ch_metadata, f_metadata);
-  EXPECT_EQ(ch_metadata.version, 1);
+  EXPECT_EQ(ch_metadata.version, 2);
   EXPECT_EQ(ch_metadata.dataset, dataset::kXnasItch);
   EXPECT_EQ(ch_metadata.schema, Schema::Definition);
   EXPECT_EQ(ch_metadata.start.time_since_epoch().count(), 1633305600000000000);


### PR DESCRIPTION
### Enhancements
- Added `Upgrade()` method to `Metadata` to update the metadata fields according to a
  `VersionUpgradePolicy`
- Added new publisher values for `XNAS.BASIC` and `XNAS.NLS`

### Bug fixes
- Fixed issue where `Metadata` wasn't upgraded when passing
  `VersionUpgradePolicy::Upgrade`
