### PR TITLE
VER: Release 0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.27.0 - TBD
+## 0.27.0 - 2025-01-07
 
 ### Breaking changes
 - Converted the `UserDefinedInstrument` enum class to an enum to safely allow handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.27.0 - TBD
+
+### Breaking changes
+- Converted the `UserDefinedInstrument` enum class to an enum to safely allow handling
+  invalid data and adding future variants
+- Updated the value of the `kMaxRecordLen` constant for the changes to
+  `InstrumentDefMsg` in version 3
+
+### Enhancements
+- Added `v3` namespace in preparation for future DBN version 3 release. DBN version 2
+  remains the current and default version
+- Added `v3::InstrumentDefMsg` record with new fields to support normalizing multi-leg
+  strategy definitions
+  - Removal of statistics-schema related fields `trading_reference_price`,
+    `trading_reference_date`, and `settl_price_type`
+  - Removal of the status-schema related field `md_security_trading_status`
+
 ## 0.26.0 - 2024-12-17
 
 ### Breaking changes
@@ -261,7 +278,8 @@ fields for `SymbolMappingMsg`, and extends the symbol field length for `SymbolMa
 Users who wish to convert DBN v1 files to v2 can use the `dbn-cli` tool available in the [databento-dbn](https://github.com/databento/dbn/) crate.
 On a future date, the Databento live and historical APIs will stop serving DBN v1.
 
-This release is fully compatible with both DBN v1 and v2, and so should be seamless for most users.
+This release is fully compatible with both DBN v1 and v2, and so the change should be
+seamless for most users.
 
 ### Enhancements
 
@@ -288,7 +306,7 @@ This release is fully compatible with both DBN v1 and v2, and so should be seaml
 
 - The old `InstrumentDefMsg` is now `InstrumentDefMsgV1` in `compat.hpp`
 - The old `SymbolMappingMsg` is now `SymbolMappingMsgV1` in `compat.hpp`
-- Converted the following enums to enum classes to allow safely adding new variants:
+- Converted the following enum classes to enums to allow safely adding new variants:
   `SecurityUpdateAction` and `SType`
 - Renamed `dummy` to `reserved` in `InstrumentDefMsg`
 - Removed `reserved2`, `reserved3`, `reserved4`, and `reserved5` from `InstrumentDefMsg`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.14)
 # Project details
 #
 
-project("databento" VERSION 0.26.0 LANGUAGES CXX)
+project("databento" VERSION 0.27.0 LANGUAGES CXX)
 string(TOUPPER ${PROJECT_NAME} PROJECT_NAME_UPPERCASE)
 
 #

--- a/cmake/SourcesAndHeaders.cmake
+++ b/cmake/SourcesAndHeaders.cmake
@@ -33,6 +33,7 @@ set(headers
   include/databento/timeseries.hpp
   include/databento/v1.hpp
   include/databento/v2.hpp
+  include/databento/v3.hpp
   include/databento/with_ts_out.hpp
   src/stream_op_helper.hpp
 )
@@ -67,4 +68,5 @@ set(sources
   src/symbol_map.cpp
   src/symbology.cpp
   src/v1.cpp
+  src/v3.cpp
 )

--- a/include/databento/enums.hpp
+++ b/include/databento/enums.hpp
@@ -220,10 +220,13 @@ enum SecurityUpdateAction : char {
 }
 using security_update_action::SecurityUpdateAction;
 
-enum class UserDefinedInstrument : char {
+namespace user_defined_instrument {
+enum UserDefinedInstrument : char {
   No = 'N',
   Yes = 'Y',
 };
+}
+using user_defined_instrument::UserDefinedInstrument;
 
 namespace stat_type {
 // The type of statistic contained in a StatMsg.

--- a/include/databento/record.hpp
+++ b/include/databento/record.hpp
@@ -14,9 +14,13 @@
 #include "databento/exceptions.hpp"  // InvalidArgumentError
 #include "databento/flag_set.hpp"    // FlagSet
 #include "databento/publishers.hpp"  // Publisher
-#include "databento/with_ts_out.hpp"
 
 namespace databento {
+// Forward declare
+namespace v3 {
+struct InstrumentDefMsg;
+}
+
 // Common data for all Databento Records.
 struct RecordHeader {
   static constexpr std::size_t kLengthMultiplier =
@@ -371,6 +375,7 @@ static_assert(alignof(StatusMsg) == 8, "Must have 8-byte alignment");
 struct InstrumentDefMsg {
   static bool HasRType(RType rtype) { return rtype == RType::InstrumentDef; }
 
+  v3::InstrumentDefMsg ToV3() const;
   UnixNanos IndexTs() const { return ts_recv; }
   const char* Currency() const { return currency.data(); }
   const char* SettlCurrency() const { return settl_currency.data(); }
@@ -780,6 +785,5 @@ std::ostream& operator<<(std::ostream& stream,
                          const SymbolMappingMsg& symbol_mapping_msg);
 
 // The length in bytes of the largest record type.
-static constexpr std::size_t kMaxRecordLen =
-    sizeof(WithTsOut<InstrumentDefMsg>);
+static constexpr std::size_t kMaxRecordLen = 520 + 8;
 }  // namespace databento

--- a/pkg/PKGBUILD
+++ b/pkg/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Databento <support@databento.com>
 _pkgname=databento-cpp
 pkgname=databento-cpp-git
-pkgver=0.26.0
+pkgver=0.27.0
 pkgrel=1
 pkgdesc="Official C++ client for Databento"
 arch=('any')

--- a/src/record.cpp
+++ b/src/record.cpp
@@ -5,6 +5,7 @@
 #include "databento/enums.hpp"
 #include "databento/exceptions.hpp"  // InvalidArgumentError
 #include "databento/fixed_price.hpp"
+#include "databento/v3.hpp"
 #include "stream_op_helper.hpp"
 
 using databento::Record;
@@ -105,6 +106,96 @@ databento::RType Record::RTypeFromSchema(const Schema schema) {
 }
 
 using databento::InstrumentDefMsg;
+
+databento::v3::InstrumentDefMsg InstrumentDefMsg::ToV3() const {
+  v3::InstrumentDefMsg ret{
+      RecordHeader{
+          sizeof(v3::InstrumentDefMsg) / RecordHeader::kLengthMultiplier,
+          RType::InstrumentDef, hd.publisher_id, hd.instrument_id, hd.ts_event},
+      ts_recv,
+      min_price_increment,
+      display_factor,
+      expiration,
+      activation,
+      high_limit_price,
+      low_limit_price,
+      max_price_variation,
+      unit_of_measure_qty,
+      min_price_increment_amount,
+      price_ratio,
+      strike_price,
+      raw_instrument_id,
+      kUndefPrice,
+      kUndefPrice,
+      inst_attrib_value,
+      underlying_id,
+      market_depth_implied,
+      market_depth,
+      market_segment_id,
+      max_trade_vol,
+      min_lot_size,
+      min_lot_size_block,
+      min_lot_size_round_lot,
+      min_trade_vol,
+      contract_multiplier,
+      decay_quantity,
+      original_contract_size,
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      appl_id,
+      maturity_year,
+      decay_start_date,
+      channel_id,
+      {},
+      {},
+      currency,
+      settl_currency,
+      secsubtype,
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      instrument_class,
+      match_algorithm,
+      main_fraction,
+      price_display_format,
+      sub_fraction,
+      underlying_product,
+      security_update_action,
+      maturity_month,
+      maturity_day,
+      maturity_week,
+      user_defined_instrument,
+      contract_multiplier_unit,
+      flow_schedule_type,
+      tick_rule,
+      {},
+      Side::None,
+      {}};
+  std::copy(raw_symbol.begin(), raw_symbol.end(), ret.raw_symbol.begin());
+  std::copy(group.begin(), group.end(), ret.group.begin());
+  std::copy(exchange.begin(), exchange.end(), ret.exchange.begin());
+  std::copy(asset.begin(), asset.end(), ret.asset.begin());
+  std::copy(cfi.begin(), cfi.end(), ret.cfi.begin());
+  std::copy(security_type.begin(), security_type.end(),
+            ret.security_type.begin());
+  std::copy(unit_of_measure.begin(), unit_of_measure.end(),
+            ret.unit_of_measure.begin());
+  std::copy(underlying.begin(), underlying.end(), ret.underlying.begin());
+  std::copy(strike_price_currency.begin(), strike_price_currency.end(),
+            ret.strike_price_currency.begin());
+  return ret;
+}
 
 bool databento::operator==(const InstrumentDefMsg& lhs,
                            const InstrumentDefMsg& rhs) {

--- a/src/v1.cpp
+++ b/src/v1.cpp
@@ -4,8 +4,12 @@
 #include <cstdint>
 #include <limits>  // numeric_limits
 
+#include "databento/constants.hpp"
 #include "databento/fixed_price.hpp"  // FixedPx
-#include "stream_op_helper.hpp"       // MakeString, StreamOpBuilder
+#include "databento/record.hpp"
+#include "databento/v2.hpp"
+#include "databento/v3.hpp"
+#include "stream_op_helper.hpp"  // MakeString, StreamOpBuilder
 
 namespace databento {
 namespace v1 {
@@ -79,6 +83,96 @@ v2::InstrumentDefMsg InstrumentDefMsg::ToV2() const {
   std::copy(settl_currency.begin(), settl_currency.end(),
             ret.settl_currency.begin());
   std::copy(secsubtype.begin(), secsubtype.end(), ret.secsubtype.begin());
+  std::copy(raw_symbol.begin(), raw_symbol.end(), ret.raw_symbol.begin());
+  std::copy(group.begin(), group.end(), ret.group.begin());
+  std::copy(exchange.begin(), exchange.end(), ret.exchange.begin());
+  std::copy(asset.begin(), asset.end(), ret.asset.begin());
+  std::copy(cfi.begin(), cfi.end(), ret.cfi.begin());
+  std::copy(security_type.begin(), security_type.end(),
+            ret.security_type.begin());
+  std::copy(unit_of_measure.begin(), unit_of_measure.end(),
+            ret.unit_of_measure.begin());
+  std::copy(underlying.begin(), underlying.end(), ret.underlying.begin());
+  std::copy(strike_price_currency.begin(), strike_price_currency.end(),
+            ret.strike_price_currency.begin());
+  return ret;
+}
+
+v3::InstrumentDefMsg InstrumentDefMsg::ToV3() const {
+  v3::InstrumentDefMsg ret{
+      RecordHeader{
+          sizeof(v3::InstrumentDefMsg) / RecordHeader::kLengthMultiplier,
+          RType::InstrumentDef, hd.publisher_id, hd.instrument_id, hd.ts_event},
+      ts_recv,
+      min_price_increment,
+      display_factor,
+      expiration,
+      activation,
+      high_limit_price,
+      low_limit_price,
+      max_price_variation,
+      unit_of_measure_qty,
+      min_price_increment_amount,
+      price_ratio,
+      strike_price,
+      raw_instrument_id,
+      kUndefPrice,
+      kUndefPrice,
+      inst_attrib_value,
+      underlying_id,
+      market_depth_implied,
+      market_depth,
+      market_segment_id,
+      max_trade_vol,
+      min_lot_size,
+      min_lot_size_block,
+      min_lot_size_round_lot,
+      min_trade_vol,
+      contract_multiplier,
+      decay_quantity,
+      original_contract_size,
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      appl_id,
+      maturity_year,
+      decay_start_date,
+      channel_id,
+      {},
+      {},
+      currency,
+      settl_currency,
+      secsubtype,
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      instrument_class,
+      match_algorithm,
+      main_fraction,
+      price_display_format,
+      sub_fraction,
+      underlying_product,
+      security_update_action,
+      maturity_month,
+      maturity_day,
+      maturity_week,
+      user_defined_instrument,
+      contract_multiplier_unit,
+      flow_schedule_type,
+      tick_rule,
+      {},
+      Side::None,
+      {}};
   std::copy(raw_symbol.begin(), raw_symbol.end(), ret.raw_symbol.begin());
   std::copy(group.begin(), group.end(), ret.group.begin());
   std::copy(exchange.begin(), exchange.end(), ret.exchange.begin());

--- a/src/v3.cpp
+++ b/src/v3.cpp
@@ -1,0 +1,162 @@
+#include "databento/v3.hpp"
+
+#include "databento/fixed_price.hpp"
+#include "stream_op_helper.hpp"
+
+namespace databento {
+namespace v3 {
+
+bool operator==(const InstrumentDefMsg& lhs, const InstrumentDefMsg& rhs) {
+  return lhs.hd == rhs.hd && lhs.ts_recv == rhs.ts_recv &&
+         lhs.min_price_increment == rhs.min_price_increment &&
+         lhs.display_factor == rhs.display_factor &&
+         lhs.expiration == rhs.expiration && lhs.activation == rhs.activation &&
+         lhs.high_limit_price == rhs.high_limit_price &&
+         lhs.low_limit_price == rhs.low_limit_price &&
+         lhs.max_price_variation == rhs.max_price_variation &&
+         lhs.unit_of_measure_qty == rhs.unit_of_measure_qty &&
+         lhs.min_price_increment_amount == rhs.min_price_increment_amount &&
+         lhs.price_ratio == rhs.price_ratio &&
+         lhs.strike_price == rhs.strike_price &&
+         lhs.raw_instrument_id == rhs.raw_instrument_id &&
+         lhs.leg_price == rhs.leg_price && lhs.leg_delta == rhs.leg_delta &&
+         lhs.inst_attrib_value == rhs.inst_attrib_value &&
+         lhs.underlying_id == rhs.underlying_id &&
+         lhs.market_depth_implied == rhs.market_depth_implied &&
+         lhs.market_depth == rhs.market_depth &&
+         lhs.market_segment_id == rhs.market_segment_id &&
+         lhs.max_trade_vol == rhs.max_trade_vol &&
+         lhs.min_lot_size == rhs.min_lot_size &&
+         lhs.min_lot_size_block == rhs.min_lot_size_block &&
+         lhs.min_lot_size_round_lot == rhs.min_lot_size_round_lot &&
+         lhs.min_trade_vol == rhs.min_trade_vol &&
+         lhs.contract_multiplier == rhs.contract_multiplier &&
+         lhs.decay_quantity == rhs.decay_quantity &&
+         lhs.original_contract_size == rhs.original_contract_size &&
+         lhs.leg_instrument_id == rhs.leg_instrument_id &&
+         lhs.leg_ratio_price_numerator == rhs.leg_ratio_price_numerator &&
+         lhs.leg_ratio_price_denominator == rhs.leg_ratio_price_denominator &&
+         lhs.leg_ratio_qty_numerator == rhs.leg_ratio_qty_numerator &&
+         lhs.leg_ratio_qty_denominator == rhs.leg_ratio_qty_denominator &&
+         lhs.leg_underlying_id == rhs.leg_underlying_id &&
+         lhs.appl_id == rhs.appl_id && lhs.maturity_year == rhs.maturity_year &&
+         lhs.decay_start_date == rhs.decay_start_date &&
+         lhs.channel_id == rhs.channel_id && lhs.leg_count == rhs.leg_count &&
+         lhs.leg_index == rhs.leg_index && lhs.currency == rhs.currency &&
+         lhs.settl_currency == rhs.settl_currency &&
+         lhs.secsubtype == rhs.secsubtype && lhs.raw_symbol == rhs.raw_symbol &&
+         lhs.group == rhs.group && lhs.exchange == rhs.exchange &&
+         lhs.asset == rhs.asset && lhs.cfi == rhs.cfi &&
+         lhs.security_type == rhs.security_type &&
+         lhs.unit_of_measure == rhs.unit_of_measure &&
+         lhs.underlying == rhs.underlying &&
+         lhs.strike_price_currency == rhs.strike_price_currency &&
+         lhs.leg_raw_symbol == rhs.leg_raw_symbol &&
+         lhs.instrument_class == rhs.instrument_class &&
+         lhs.match_algorithm == rhs.match_algorithm &&
+         lhs.main_fraction == rhs.main_fraction &&
+         lhs.price_display_format == rhs.price_display_format &&
+         lhs.sub_fraction == rhs.sub_fraction &&
+         lhs.underlying_product == rhs.underlying_product &&
+         lhs.security_update_action == rhs.security_update_action &&
+         lhs.maturity_month == rhs.maturity_month &&
+         lhs.maturity_day == rhs.maturity_day &&
+         lhs.maturity_week == rhs.maturity_week &&
+         lhs.user_defined_instrument == rhs.user_defined_instrument &&
+         lhs.contract_multiplier_unit == rhs.contract_multiplier_unit &&
+         lhs.flow_schedule_type == rhs.flow_schedule_type &&
+         lhs.tick_rule == rhs.tick_rule &&
+         lhs.leg_instrument_class == rhs.leg_instrument_class &&
+         lhs.leg_side == rhs.leg_side;
+}
+
+std::string ToString(const InstrumentDefMsg& instr_def_msg) {
+  return MakeString(instr_def_msg);
+}
+std::ostream& operator<<(std::ostream& stream,
+                         const InstrumentDefMsg& instr_def_msg) {
+  return StreamOpBuilder{stream}
+      .SetSpacer("\n    ")
+      .SetTypeName("v1::InstrumentDefMsg")
+      .Build()
+      .AddField("hd", instr_def_msg.hd)
+      .AddField("ts_recv", instr_def_msg.ts_recv)
+      .AddField("min_price_increment", FixPx{instr_def_msg.min_price_increment})
+      .AddField("display_factor", FixPx{instr_def_msg.display_factor})
+      .AddField("expiration", instr_def_msg.expiration)
+      .AddField("activation", instr_def_msg.activation)
+      .AddField("high_limit_price", FixPx{instr_def_msg.high_limit_price})
+      .AddField("low_limit_price", FixPx{instr_def_msg.low_limit_price})
+      .AddField("max_price_variation", FixPx{instr_def_msg.max_price_variation})
+      .AddField("unit_of_measure_qty", FixPx{instr_def_msg.unit_of_measure_qty})
+      .AddField("min_price_increment_amount",
+                FixPx{instr_def_msg.min_price_increment_amount})
+      .AddField("price_ratio", FixPx{instr_def_msg.price_ratio})
+      .AddField("strike_price", FixPx{instr_def_msg.strike_price})
+      .AddField("raw_instrument_id", instr_def_msg.raw_instrument_id)
+      .AddField("leg_price", FixPx{instr_def_msg.leg_price})
+      .AddField("leg_delta", FixPx{instr_def_msg.leg_delta})
+      .AddField("inst_attrib_value", instr_def_msg.inst_attrib_value)
+      .AddField("underlying_id", instr_def_msg.underlying_id)
+      .AddField("market_depth_implied", instr_def_msg.market_depth_implied)
+      .AddField("market_depth", instr_def_msg.market_depth)
+      .AddField("market_segment_id", instr_def_msg.market_segment_id)
+      .AddField("max_trade_vol", instr_def_msg.max_trade_vol)
+      .AddField("min_lot_size", instr_def_msg.min_lot_size)
+      .AddField("min_lot_size_block", instr_def_msg.min_lot_size_block)
+      .AddField("min_lot_size_round_lot", instr_def_msg.min_lot_size_round_lot)
+      .AddField("min_trade_vol", instr_def_msg.min_trade_vol)
+      .AddField("contract_multiplier", instr_def_msg.contract_multiplier)
+      .AddField("decay_quantity", instr_def_msg.decay_quantity)
+      .AddField("original_contract_size", instr_def_msg.original_contract_size)
+      .AddField("leg_instrument_id", instr_def_msg.leg_instrument_id)
+      .AddField("leg_ratio_price_numerator",
+                instr_def_msg.leg_ratio_price_numerator)
+      .AddField("leg_ratio_price_denominator",
+                instr_def_msg.leg_ratio_price_denominator)
+      .AddField("leg_ratio_qty_numerator",
+                instr_def_msg.leg_ratio_qty_numerator)
+      .AddField("leg_ratio_qty_denominator",
+                instr_def_msg.leg_ratio_qty_denominator)
+      .AddField("leg_underlying_id", instr_def_msg.leg_underlying_id)
+      .AddField("appl_id", instr_def_msg.appl_id)
+      .AddField("maturity_year", instr_def_msg.maturity_year)
+      .AddField("decay_start_date", instr_def_msg.decay_start_date)
+      .AddField("channel_id", instr_def_msg.channel_id)
+      .AddField("leg_count", instr_def_msg.leg_count)
+      .AddField("leg_index", instr_def_msg.leg_index)
+      .AddField("currency", instr_def_msg.currency)
+      .AddField("settl_currency", instr_def_msg.settl_currency)
+      .AddField("secsubtype", instr_def_msg.secsubtype)
+      .AddField("raw_symbol", instr_def_msg.raw_symbol)
+      .AddField("group", instr_def_msg.group)
+      .AddField("exchange", instr_def_msg.exchange)
+      .AddField("asset", instr_def_msg.asset)
+      .AddField("cfi", instr_def_msg.cfi)
+      .AddField("security_type", instr_def_msg.security_type)
+      .AddField("unit_of_measure", instr_def_msg.unit_of_measure)
+      .AddField("underlying", instr_def_msg.underlying)
+      .AddField("strike_price_currency", instr_def_msg.strike_price_currency)
+      .AddField("leg_raw_symbol", instr_def_msg.leg_raw_symbol)
+      .AddField("instrument_class", instr_def_msg.instrument_class)
+      .AddField("match_algorithm", instr_def_msg.match_algorithm)
+      .AddField("main_fraction", instr_def_msg.main_fraction)
+      .AddField("price_display_format", instr_def_msg.price_display_format)
+      .AddField("sub_fraction", instr_def_msg.sub_fraction)
+      .AddField("underlying_product", instr_def_msg.underlying_product)
+      .AddField("security_update_action", instr_def_msg.security_update_action)
+      .AddField("maturity_month", instr_def_msg.maturity_month)
+      .AddField("maturity_day", instr_def_msg.maturity_day)
+      .AddField("maturity_week", instr_def_msg.maturity_week)
+      .AddField("user_defined_instrument",
+                instr_def_msg.user_defined_instrument)
+      .AddField("contract_multiplier_unit",
+                instr_def_msg.contract_multiplier_unit)
+      .AddField("flow_schedule_type", instr_def_msg.flow_schedule_type)
+      .AddField("tick_rule", instr_def_msg.tick_rule)
+      .AddField("leg_instrument_class", instr_def_msg.leg_instrument_class)
+      .AddField("leg_side", instr_def_msg.leg_side)
+      .Finish();
+}
+}  // namespace v3
+}  // namespace databento


### PR DESCRIPTION
##### Breaking changes
- Converted the `UserDefinedInstrument` enum class to an enum to safely allow handling
  invalid data and adding future variants
- Updated the value of the `kMaxRecordLen` constant for the changes to
  `InstrumentDefMsg` in version 3

##### Enhancements
- Added `v3` namespace in preparation for future DBN version 3 release. DBN version 2
  remains the current and default version
- Added `v3::InstrumentDefMsg` record with new fields to support normalizing multi-leg
  strategy definitions
  - Removal of statistics-schema related fields `trading_reference_price`,
    `trading_reference_date`, and `settl_price_type`
  - Removal of the status-schema related field `md_security_trading_status`