### PR TITLE
VER: Release 0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.38.3 - TBD
+
+### Bug fixes
+- Removed `Intraday` variant from `DatasetCondition` enum
+
 ## 0.38.2 - 2025-07-01
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 - Removed `Intraday` variant from `DatasetCondition` enum
+- Fixed potential corrupted records when upgrading DBN versions in live clients
 
 ## 0.38.2 - 2025-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,6 @@
 # Changelog
 
-## 0.39.0 - TBD
-
-### Bug fixes
-- Removed `Intraday` variant from `DatasetCondition` enum
-- Fixed potential corrupted records when upgrading DBN versions in live clients
+## 0.39.0 - 2025-07-15
 
 ### Breaking changes
 - Renamed the following Venue, Dataset, and Publishers:
@@ -12,6 +8,10 @@
     - `XEER.EOBI` to `XEEE.EOBI`
     - `XEER.EOBI.XEER` to `XEEE.EOBI.XEEE`
     - `XEER.EOBI.XOFF` to `XEEE.EOBI.XOFF`
+
+### Bug fixes
+- Fixed potential corrupted records when upgrading DBN versions in live clients
+- Removed unused `Intraday` variant from `DatasetCondition` enum
 
 ## 0.38.2 - 2025-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
 
-## 0.38.3 - TBD
+## 0.39.0 - TBD
 
 ### Bug fixes
 - Removed `Intraday` variant from `DatasetCondition` enum
 - Fixed potential corrupted records when upgrading DBN versions in live clients
+
+### Breaking changes
+- Renamed the following Venue, Dataset, and Publishers:
+    - `XEER` to `XEEE`
+    - `XEER.EOBI` to `XEEE.EOBI`
+    - `XEER.EOBI.XEER` to `XEEE.EOBI.XEEE`
+    - `XEER.EOBI.XOFF` to `XEEE.EOBI.XOFF`
 
 ## 0.38.2 - 2025-07-01
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.24..4.0)
 
 project(
   databento
-  VERSION 0.38.2
+  VERSION 0.39.0
   LANGUAGES CXX
   DESCRIPTION "Official Databento client library"
 )

--- a/include/databento/enums.hpp
+++ b/include/databento/enums.hpp
@@ -107,7 +107,6 @@ enum class DatasetCondition : std::uint8_t {
   Degraded,
   Pending,
   Missing,
-  Intraday,
 };
 
 // Sentinel values for different DBN record types.

--- a/include/databento/live_blocking.hpp
+++ b/include/databento/live_blocking.hpp
@@ -7,7 +7,6 @@
 #include <optional>
 #include <string>
 #include <string_view>
-#include <utility>  // pair
 #include <vector>
 
 #include "databento/datetime.hpp"  // UnixNanos
@@ -40,8 +39,6 @@ class LiveBlocking {
   std::uint16_t Port() const { return port_; }
   bool SendTsOut() const { return send_ts_out_; }
   VersionUpgradePolicy UpgradePolicy() const { return upgrade_policy_; }
-  // The the first member of the pair will be true, when the heartbeat interval
-  // was overridden.
   std::optional<std::chrono::seconds> HeartbeatInterval() const {
     return heartbeat_interval_;
   }

--- a/include/databento/live_threaded.hpp
+++ b/include/databento/live_threaded.hpp
@@ -7,7 +7,6 @@
 #include <optional>
 #include <string>
 #include <string_view>
-#include <utility>  // pair
 #include <vector>
 
 #include "databento/datetime.hpp"              // UnixNanos
@@ -53,8 +52,6 @@ class LiveThreaded {
   std::uint16_t Port() const;
   bool SendTsOut() const;
   VersionUpgradePolicy UpgradePolicy() const;
-  // The the first member of the pair will be true, when the heartbeat interval
-  // was overridden.
   std::optional<std::chrono::seconds> HeartbeatInterval() const;
   const std::vector<LiveSubscription>& Subscriptions() const;
   std::vector<LiveSubscription>& Subscriptions();

--- a/include/databento/publishers.hpp
+++ b/include/databento/publishers.hpp
@@ -108,7 +108,7 @@ enum class Venue : std::uint16_t {
   // Eurex Exchange
   Xeur = 50,
   // European Energy Exchange
-  Xeer = 51,
+  Xeee = 51,
 };
 
 // A source of data.
@@ -190,7 +190,7 @@ enum class Dataset : std::uint16_t {
   // Eurex EOBI
   XeurEobi = 38,
   // European Energy Exchange EOBI
-  XeerEobi = 39,
+  XeeeEobi = 39,
 };
 
 // A specific Venue from a specific data source.
@@ -398,11 +398,11 @@ enum class Publisher : std::uint16_t {
   // Eurex EOBI
   XeurEobiXeur = 101,
   // European Energy Exchange EOBI
-  XeerEobiXeer = 102,
+  XeeeEobiXeee = 102,
   // Eurex EOBI - Off-Market Trades
   XeurEobiXoff = 103,
   // European Energy Exchange EOBI - Off-Market Trades
-  XeerEobiXoff = 104,
+  XeeeEobiXoff = 104,
 };
 
 // Get a Publisher's Venue.

--- a/pkg/PKGBUILD
+++ b/pkg/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Databento <support@databento.com>
 _pkgname=databento-cpp
 pkgname=databento-cpp-git
-pkgver=0.38.2
+pkgver=0.39.0
 pkgrel=1
 pkgdesc="Official C++ client for Databento"
 arch=('any')

--- a/src/enums.cpp
+++ b/src/enums.cpp
@@ -234,9 +234,6 @@ const char* ToString(DatasetCondition condition) {
     case DatasetCondition::Missing: {
       return "missing";
     }
-    case DatasetCondition::Intraday: {
-      return "intraday";
-    }
     default: {
       return "unknown";
     }
@@ -1134,9 +1131,6 @@ DatasetCondition FromString(const std::string& str) {
   }
   if (str == "missing") {
     return DatasetCondition::Missing;
-  }
-  if (str == "intraday") {
-    return DatasetCondition::Intraday;
   }
   throw InvalidArgumentError{"FromString<DatasetCondition>", "str",
                              "unknown value '" + str + '\''};

--- a/src/live_blocking.cpp
+++ b/src/live_blocking.cpp
@@ -189,10 +189,12 @@ const databento::Record* LiveBlocking::NextRecord(
     }
   }
   current_record_ = Record{BufferRecordHeader()};
-  buffer_.Consume(current_record_.Size());
+  const auto bytes_to_consume = current_record_.Size();
   current_record_ =
       DbnDecoder::DecodeRecordCompat(version_, upgrade_policy_, send_ts_out_,
                                      &compat_buffer_, current_record_);
+  // Can't consume til after upgrade as Consume may shift
+  buffer_.Consume(bytes_to_consume);
   return &current_record_;
 }
 

--- a/src/publishers.cpp
+++ b/src/publishers.cpp
@@ -161,8 +161,8 @@ const char* ToString(Venue venue) {
     case Venue::Xeur: {
       return "XEUR";
     }
-    case Venue::Xeer: {
-      return "XEER";
+    case Venue::Xeee: {
+      return "XEEE";
     }
     default: {
       return "Unknown";
@@ -327,8 +327,8 @@ Venue FromString(const std::string& str) {
   if (str == "XEUR") {
     return Venue::Xeur;
   }
-  if (str == "XEER") {
-    return Venue::Xeer;
+  if (str == "XEEE") {
+    return Venue::Xeee;
   }
   throw InvalidArgumentError{"FromString<Venue>", "str",
                              "unknown value '" + str + '\''};
@@ -450,8 +450,8 @@ const char* ToString(Dataset dataset) {
     case Dataset::XeurEobi: {
       return "XEUR.EOBI";
     }
-    case Dataset::XeerEobi: {
-      return "XEER.EOBI";
+    case Dataset::XeeeEobi: {
+      return "XEEE.EOBI";
     }
     default: {
       return "Unknown";
@@ -580,8 +580,8 @@ Dataset FromString(const std::string& str) {
   if (str == "XEUR.EOBI") {
     return Dataset::XeurEobi;
   }
-  if (str == "XEER.EOBI") {
-    return Dataset::XeerEobi;
+  if (str == "XEEE.EOBI") {
+    return Dataset::XeeeEobi;
   }
   throw InvalidArgumentError{"FromString<Dataset>", "str",
                              "unknown value '" + str + '\''};
@@ -892,13 +892,13 @@ Venue PublisherVenue(Publisher publisher) {
     case Publisher::XeurEobiXeur: {
       return Venue::Xeur;
     }
-    case Publisher::XeerEobiXeer: {
-      return Venue::Xeer;
+    case Publisher::XeeeEobiXeee: {
+      return Venue::Xeee;
     }
     case Publisher::XeurEobiXoff: {
       return Venue::Xoff;
     }
-    case Publisher::XeerEobiXoff: {
+    case Publisher::XeeeEobiXoff: {
       return Venue::Xoff;
     }
     default: {
@@ -1214,14 +1214,14 @@ Dataset PublisherDataset(Publisher publisher) {
     case Publisher::XeurEobiXeur: {
       return Dataset::XeurEobi;
     }
-    case Publisher::XeerEobiXeer: {
-      return Dataset::XeerEobi;
+    case Publisher::XeeeEobiXeee: {
+      return Dataset::XeeeEobi;
     }
     case Publisher::XeurEobiXoff: {
       return Dataset::XeurEobi;
     }
-    case Publisher::XeerEobiXoff: {
-      return Dataset::XeerEobi;
+    case Publisher::XeeeEobiXoff: {
+      return Dataset::XeeeEobi;
     }
     default: {
       throw InvalidArgumentError{
@@ -1537,14 +1537,14 @@ const char* ToString(Publisher publisher) {
     case Publisher::XeurEobiXeur: {
       return "XEUR.EOBI.XEUR";
     }
-    case Publisher::XeerEobiXeer: {
-      return "XEER.EOBI.XEER";
+    case Publisher::XeeeEobiXeee: {
+      return "XEEE.EOBI.XEEE";
     }
     case Publisher::XeurEobiXoff: {
       return "XEUR.EOBI.XOFF";
     }
-    case Publisher::XeerEobiXoff: {
-      return "XEER.EOBI.XOFF";
+    case Publisher::XeeeEobiXoff: {
+      return "XEEE.EOBI.XOFF";
     }
     default: {
       return "Unknown";
@@ -1862,14 +1862,14 @@ Publisher FromString(const std::string& str) {
   if (str == "XEUR.EOBI.XEUR") {
     return Publisher::XeurEobiXeur;
   }
-  if (str == "XEER.EOBI.XEER") {
-    return Publisher::XeerEobiXeer;
+  if (str == "XEEE.EOBI.XEEE") {
+    return Publisher::XeeeEobiXeee;
   }
   if (str == "XEUR.EOBI.XOFF") {
     return Publisher::XeurEobiXoff;
   }
-  if (str == "XEER.EOBI.XOFF") {
-    return Publisher::XeerEobiXoff;
+  if (str == "XEEE.EOBI.XOFF") {
+    return Publisher::XeeeEobiXoff;
   }
   throw InvalidArgumentError{"FromString<Publisher>", "str",
                              "unknown value '" + str + '\''};


### PR DESCRIPTION
### Breaking changes
- Renamed the following Venue, Dataset, and Publishers:
    - `XEER` to `XEEE`
    - `XEER.EOBI` to `XEEE.EOBI`
    - `XEER.EOBI.XEER` to `XEEE.EOBI.XEEE`
    - `XEER.EOBI.XOFF` to `XEEE.EOBI.XOFF`

### Bug fixes
- Fixed potential corrupted records when upgrading DBN versions in live clients
- Removed unused `Intraday` variant from `DatasetCondition` enum
